### PR TITLE
Add password prompt for P12 files

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wagoodman/go-partybus"
 
 	"github.com/anchore/quill/quill/event"
+	"github.com/anchore/quill/quill/event/monitor"
 )
 
 var publisher partybus.Publisher
@@ -56,4 +57,13 @@ func Notify(message string) {
 		Type:  event.Notification,
 		Value: message,
 	})
+}
+
+func PromptForInput(message string, sensitive bool, validators ...func(string) error) *monitor.Prompter {
+	p := monitor.NewPrompter(message, sensitive, validators...)
+	Publish(partybus.Event{
+		Type:  event.InputPrompt,
+		Value: monitor.PromptWriter(p),
+	})
+	return p
 }

--- a/quill/pem/load_p12.go
+++ b/quill/pem/load_p12.go
@@ -1,33 +1,43 @@
 package pem
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 
 	"software.sslmate.com/src/go-pkcs12"
+
+	"github.com/anchore/quill/internal/bus"
+	"github.com/anchore/quill/internal/log"
 )
 
-func LoadP12(path, password string) (crypto.PrivateKey, []*x509.Certificate, error) {
+func LoadP12(path, password string) (crypto.PrivateKey, *x509.Certificate, []*x509.Certificate, error) {
 	by, err := LoadBytesFromFileOrEnv(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to read p12 file: %w", err)
+		return nil, nil, nil, fmt.Errorf("unable to read p12 file: %w", err)
 	}
 
 	key, cert, certs, err := pkcs12.DecodeChain(by, password)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to decode p12 file: %w", err)
+		if errors.Is(err, pkcs12.ErrIncorrectPassword) && password == "" {
+			prompter := bus.PromptForInput("Enter P12 password:", true)
+			newPassword, err := prompter.GetPromptResponse(context.Background())
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("unable to get password from prompt: %w", err)
+			}
+
+			log.Redact(newPassword)
+
+			key, cert, certs, err = pkcs12.DecodeChain(by, newPassword)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("unable to decode p12 file: %w", err)
+			}
+		} else {
+			return nil, nil, nil, fmt.Errorf("unable to decode p12 file: %w", err)
+		}
 	}
 
-	if key == nil {
-		return nil, nil, fmt.Errorf("no private key found in the p12")
-	}
-
-	if cert == nil {
-		return nil, nil, fmt.Errorf("no signing certificate found in the p12")
-	}
-
-	allCerts := append([]*x509.Certificate{cert}, certs...)
-
-	return key.(crypto.PrivateKey), allCerts, nil
+	return key.(crypto.PrivateKey), cert, certs, nil
 }


### PR DESCRIPTION
Adds prompting for password input when no password was given for an encrypted P12 file:
```
$ quill p12 attach-chain /some/path/to/file.p12

[0000]  INFO quill version: [not provided]
[0000]  INFO attaching certificate chain to p12 file file=/some/path/to/file.p12
 ❖ Enter P12 password: ●●●●●●●●●●●●●●●

```