### PR TITLE
Add support for universal binaries

### DIFF
--- a/cmd/quill/cli/commands/sign.go
+++ b/cmd/quill/cli/commands/sign.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"debug/macho"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -55,11 +53,6 @@ func Sign(app *application.Application) *cobra.Command {
 }
 
 func sign(binPath string, opts options.Signing) error {
-	err := validatePathIsDarwinBinary(binPath)
-	if err != nil {
-		return err
-	}
-
 	cfg := quill.SigningConfig{
 		Path: binPath,
 	}
@@ -80,16 +73,4 @@ func sign(binPath string, opts options.Signing) error {
 	cfg.WithTimestampServer(opts.TimestampServer)
 
 	return quill.Sign(cfg)
-}
-
-func validatePathIsDarwinBinary(path string) error {
-	fi, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-
-	if _, err := macho.NewFile(fi); err != nil {
-		return fmt.Errorf("given path=%q may not be a macho formatted binary: %w", path, err)
-	}
-	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.2.1
 	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8
+	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
 	github.com/aws/aws-sdk-go v1.44.114
 	github.com/blacktop/go-macho v1.1.83
 	github.com/charmbracelet/bubbletea v0.22.1
@@ -43,7 +44,6 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
 	github.com/go-openapi/strfmt v0.21.3 // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 h1:imgMA0gN0TZx7PSa/pdWqXadBvrz8WsN6zySzCe4XX0=
 github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8/go.mod h1:+gPap4jha079qzRTUaehv+UZ6sSdaNwkH0D3b6zhTuk=
+github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb h1:iDMnx6LIjtjZ46C0akqveX83WFzhpTD3eqOthawb5vU=
+github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb/go.mod h1:DmTY2Mfcv38hsHbG78xMiTDdxFtkHpgYNVDPsF2TgHk=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -106,8 +108,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/quill/extract/extract.go
+++ b/quill/extract/extract.go
@@ -4,14 +4,55 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path"
 
 	blacktopMacho "github.com/blacktop/go-macho"
 
+	macholibre "github.com/anchore/go-macholibre"
+	"github.com/anchore/quill/internal/utils"
 	"github.com/anchore/quill/quill/macho"
 )
 
-func NewFile(path string) (*File, error) {
+func NewFile(binPath string) ([]*File, error) {
+	f, err := os.Open(binPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if macholibre.IsUniversalMachoBinary(f) {
+		var mfs []*File
+
+		dir, err := ioutil.TempDir("", "quill-extract-"+path.Base(binPath))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create temp directory to extract multi-arch binary: %w", err)
+		}
+		defer os.RemoveAll(dir)
+
+		efs, err := macholibre.Extract(f, dir)
+		if err != nil {
+			return nil, fmt.Errorf("unable to extract multi-arch binary: %w", err)
+		}
+		for _, ef := range efs {
+			mf, err := newFile(ef.Path)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse extracted multi-arch binary: %w", err)
+			}
+			mfs = append(mfs, mf)
+		}
+		return mfs, nil
+	}
+
+	mf, err := newFile(binPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse single-arch binary: %w", err)
+	}
+	return []*File{mf}, nil
+}
+
+func newFile(path string) (*File, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open file: %w", err)
@@ -33,25 +74,43 @@ func NewFile(path string) (*File, error) {
 }
 
 func ShowJSON(path string, writer io.Writer) error {
-	f, err := NewFile(path)
+	mfs, err := NewFile(path)
 	if err != nil {
 		return err
 	}
 
-	details := ParseDetails(*f)
+	var allDetails []Details
+	for _, f := range mfs {
+		details := ParseDetails(*f)
+		allDetails = append(allDetails, details)
+	}
+
 	en := json.NewEncoder(writer)
 	en.SetIndent("", "  ")
-	return en.Encode(details)
+	return en.Encode(allDetails)
 }
 
 func ShowText(path string, writer io.Writer, hideVerboseData bool) error {
-	f, err := NewFile(path)
+	mfs, err := NewFile(path)
 	if err != nil {
 		return err
 	}
 
-	details := ParseDetails(*f)
-	_, err = writer.Write([]byte(details.String(hideVerboseData)))
+	for i, f := range mfs {
+		details := ParseDetails(*f)
+		detailString := details.String(hideVerboseData)
+
+		detailString = utils.Indent(detailString, "  ")
+
+		prefix := ""
+		if i != 0 {
+			prefix = "\n"
+		}
+
+		result := fmt.Sprintf("%sBinary %d of %d:\n\n%s", prefix, i+1, len(mfs), detailString)
+
+		_, err = writer.Write([]byte(result))
+	}
 
 	return err
 }

--- a/quill/sign_test.go
+++ b/quill/sign_test.go
@@ -162,6 +162,34 @@ func TestSign(t *testing.T) {
 				test.AssertContains("Internal requirements count=1 size=48"),
 			},
 		},
+		{
+			// note: this test will fail with other architectures (e.g. arm64) since the output assertions are for x86_64
+			// but codesign will dynamically select the architecture based on the current host architecture
+			name: "sign multi arch binary - cert chain",
+			args: args{
+				id:       "ls",
+				path:     test.AssetCopy(t, "ls_universal_signed"),
+				keyFile:  test.Asset(t, "chain-leaf-key.pem"),
+				certFile: test.Asset(t, "chain.pem"),
+			},
+			assertions: []test.OutputAssertion{
+				test.AssertContains("CodeDirectory v=20500 size=643 flags=0x10000(runtime) hashes=15+2 location=embedded"),
+				test.AssertContains("Hash type=sha256 size=32"),
+				test.AssertContains("CandidateCDHash sha256=a4cd4a5f49f232086ba698ec3bba3f086f432dea"),
+				test.AssertContains("CandidateCDHashFull sha256=a4cd4a5f49f232086ba698ec3bba3f086f432deae7d6ba648895e935b5098307"),
+				test.AssertContains("CDHash=a4cd4a5f49f232086ba698ec3bba3f086f432dea"),
+				test.AssertContains("CMSDigest=a4cd4a5f49f232086ba698ec3bba3f086f432deae7d6ba648895e935b5098307"),
+				test.AssertContains("CMSDigestType=2"),
+				test.AssertContains("Signature size="), // assert not adhoc
+				test.AssertContains("Authority=quill-test-leaf"),
+				test.AssertContains("Authority=quill-test-intermediate-ca"),
+				test.AssertContains("Authority=quill-test-root-ca"),
+				test.AssertContains("Info.plist=not bound"),
+				test.AssertContains("TeamIdentifier=not set"),
+				test.AssertContains("Sealed Resources=none"),
+				test.AssertContains("Internal requirements count=1 size=44"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Updates the following commands to support taking in universal binaries:
- `sign`
- `sign-and-notaize`
- `describe`
- `extract certificates`

Closes #3 