### PR TITLE
Add environment variable hints to help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ $ quill p12 attach-chain <path-to-p12-from-apple>
 # a new P12 file was created with the same name as the original but with the suffix `-with-chain.p12`
 ```
 
-This new P12 file (with the full certificate chain) is used as many times as you need to sign binaries:
+Note: this step only needs to be done once. This new P12 file (with the full certificate chain) can be used on any platform as many times as you need to sign binaries.
 
 ```bash
 # run on **any platform** to sign the binary
-$ export QUILL_SIGNING_P12=<path-to-p12-with-chain>    # can also be base64 encoded contents instead of a file path
-$ export QUILL_SIGNING_PASSWORD=<p12-password>
+$ export QUILL_SIGN_P12=<path-to-p12-with-chain>    # can also be base64 encoded contents instead of a file path
+$ export QUILL_SIGN_PASSWORD=<p12-password>
 
 $ quill sign <path/to/binary>
 ```
@@ -63,7 +63,7 @@ builds:
         # skipped and only ad-hoc signing is performed (not cryptographic material is needed).
         #
         # note: environment variables required for signing and notarization (set in CI) but are not needed for snapshot builds
-        #    QUILL_SIGNING_P12, QUILL_SIGNING_PASSWORD, QUILL_NOTARY_KEY, QUILL_NOTARY_KEY_ID, QUILL_NOTARY_ISSUER
+        #    QUILL_SIGN_P12, QUILL_SIGN_PASSWORD, QUILL_NOTARY_KEY, QUILL_NOTARY_KEY_ID, QUILL_NOTARY_ISSUER
         - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log

--- a/cmd/quill/cli/commands/describe.go
+++ b/cmd/quill/cli/commands/describe.go
@@ -82,8 +82,7 @@ func Describe(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/extract.go
+++ b/cmd/quill/cli/commands/extract.go
@@ -13,6 +13,6 @@ func Extract(_ *application.Application) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	commonConfiguration(cmd)
+	commonConfiguration(nil, cmd, nil)
 	return cmd
 }

--- a/cmd/quill/cli/commands/extract_certificates.go
+++ b/cmd/quill/cli/commands/extract_certificates.go
@@ -55,8 +55,7 @@ func ExtractCertificates(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/notarize.go
+++ b/cmd/quill/cli/commands/notarize.go
@@ -74,8 +74,7 @@ func Notarize(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/p12.go
+++ b/cmd/quill/cli/commands/p12.go
@@ -13,6 +13,6 @@ func P12(_ *application.Application) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	commonConfiguration(cmd)
+	commonConfiguration(nil, cmd, nil)
 	return cmd
 }

--- a/cmd/quill/cli/commands/p12_attach_chain.go
+++ b/cmd/quill/cli/commands/p12_attach_chain.go
@@ -92,8 +92,7 @@ func P12AttachChain(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/p12_describe.go
+++ b/cmd/quill/cli/commands/p12_describe.go
@@ -54,8 +54,7 @@ func P12Describe(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/root.go
+++ b/cmd/quill/cli/commands/root.go
@@ -24,7 +24,7 @@ func Root(app *application.Application) *cobra.Command {
 		Example: formatRootExamples(),
 	}
 
-	commonConfiguration(cmd)
+	commonConfiguration(nil, cmd, nil)
 
 	cmd.SetVersionTemplate(fmt.Sprintf("%s {{.Version}}\n", internal.ApplicationName))
 

--- a/cmd/quill/cli/commands/sign.go
+++ b/cmd/quill/cli/commands/sign.go
@@ -15,7 +15,7 @@ var _ options.Interface = &signConfig{}
 
 type signConfig struct {
 	Path            string `yaml:"path" json:"path" mapstructure:"path"`
-	options.Signing `yaml:"signing" json:"signing" mapstructure:"signing"`
+	options.Signing `yaml:"sign" json:"sign" mapstructure:"sign"`
 }
 
 func Sign(app *application.Application) *cobra.Command {
@@ -46,8 +46,7 @@ func Sign(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/sign_and_notarize.go
+++ b/cmd/quill/cli/commands/sign_and_notarize.go
@@ -16,7 +16,7 @@ var _ options.Interface = &signConfig{}
 
 type signAndNotarizeConfig struct {
 	Path            string `yaml:"path" json:"path" mapstructure:"path"`
-	options.Signing `yaml:"signing" json:"signing" mapstructure:"signing"`
+	options.Signing `yaml:"sign" json:"sign" mapstructure:"sign"`
 	options.Notary  `yaml:"notary" json:"notary" mapstructure:"notary"`
 	options.Status  `yaml:"status" json:"status" mapstructure:"status"`
 	DryRun          bool `yaml:"dry-run" json:"dry-run" mapstructure:"dry-run"`
@@ -82,8 +82,7 @@ func SignAndNotarize(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/submission.go
+++ b/cmd/quill/cli/commands/submission.go
@@ -13,6 +13,6 @@ func Submission(_ *application.Application) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	commonConfiguration(cmd)
+	commonConfiguration(nil, cmd, nil)
 	return cmd
 }

--- a/cmd/quill/cli/commands/submission_list.go
+++ b/cmd/quill/cli/commands/submission_list.go
@@ -70,8 +70,7 @@ func SubmissionList(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/submission_logs.go
+++ b/cmd/quill/cli/commands/submission_logs.go
@@ -68,8 +68,7 @@ func SubmissionLogs(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/submission_status.go
+++ b/cmd/quill/cli/commands/submission_status.go
@@ -100,8 +100,7 @@ func SubmissionStatus(app *application.Application) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-	commonConfiguration(cmd)
+	commonConfiguration(app, cmd, opts)
 
 	return cmd
 }

--- a/cmd/quill/cli/commands/utils.go
+++ b/cmd/quill/cli/commands/utils.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/anchore/quill/cmd/quill/cli/application"
+	"github.com/anchore/quill/cmd/quill/cli/options"
 	"github.com/anchore/quill/internal/bus"
 )
 
@@ -30,7 +32,19 @@ func chainArgs(processors ...func(cmd *cobra.Command, args []string) error) func
 	}
 }
 
-func commonConfiguration(cmd *cobra.Command) {
+func commonConfiguration(app *application.Application, cmd *cobra.Command, opts options.Interface) {
+	if opts != nil {
+		opts.AddFlags(cmd.Flags())
+
+		if app != nil {
+			// we want to be able to attach config binding information to the help output
+			cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+				_ = app.Setup(opts)(cmd, args)
+				cmd.Parent().HelpFunc()(cmd, args)
+			})
+		}
+	}
+
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	cmd.SetHelpTemplate(`{{if (or .Long .Short)}}{{.Long}}{{if not .Long}}{{.Short}}{{end}}

--- a/cmd/quill/cli/commands/version.go
+++ b/cmd/quill/cli/commands/version.go
@@ -67,7 +67,7 @@ func Version(app *application.Application) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&format, "output", "o", "text", "the format to show the results (allowable: [text json])")
 
-	commonConfiguration(cmd)
+	commonConfiguration(nil, cmd, nil)
 
 	return cmd
 }

--- a/cmd/quill/cli/options/signing.go
+++ b/cmd/quill/cli/options/signing.go
@@ -11,7 +11,7 @@ var _ Interface = &Signing{}
 
 type Signing struct {
 	// bound options
-	Identity        string `yaml:"override-identity" json:"override-identity" mapstructure:"override-identity"`
+	Identity        string `yaml:"identity" json:"identity" mapstructure:"identity"`
 	P12             string `yaml:"p12" json:"p12" mapstructure:"p12"`
 	TimestampServer string `yaml:"timestamp-server" json:"timestamp-server" mapstructure:"timestamp-server"`
 	AdHoc           bool   `yaml:"ad-hoc" json:"ad-hoc" mapstructure:"ad-hoc"`
@@ -58,21 +58,21 @@ func (o *Signing) AddFlags(flags *pflag.FlagSet) {
 }
 
 func (o *Signing) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
-	if err := Bind(v, "signing.override-identity", flags.Lookup("identity")); err != nil {
+	if err := Bind(v, "sign.override-identity", flags.Lookup("identity")); err != nil {
 		return err
 	}
-	if err := Bind(v, "signing.p12", flags.Lookup("p12")); err != nil {
+	if err := Bind(v, "sign.p12", flags.Lookup("p12")); err != nil {
 		return err
 	}
-	if err := Bind(v, "signing.timestamp-server", flags.Lookup("timestamp-server")); err != nil {
+	if err := Bind(v, "sign.timestamp-server", flags.Lookup("timestamp-server")); err != nil {
 		return err
 	}
-	if err := Bind(v, "signing.ad-hoc", flags.Lookup("ad-hoc")); err != nil {
+	if err := Bind(v, "sign.ad-hoc", flags.Lookup("ad-hoc")); err != nil {
 		return err
 	}
 
 	// set default values for non-bound struct items
-	v.SetDefault("signing.password", o.Password)
+	v.SetDefault("sign.password", o.Password)
 
 	return nil
 }

--- a/cmd/quill/cli/options/utils.go
+++ b/cmd/quill/cli/options/utils.go
@@ -25,6 +25,10 @@ func Bind(v *viper.Viper, configKey string, flag *pflag.Flag) error {
 		return fmt.Errorf("unable to bind config-key=%q to CLI flag=%q: %w", configKey, flag.Name, err)
 	}
 
+	envVar := strings.ToUpper(strings.NewReplacer(".", "_", "-", "_").Replace(internal.ApplicationName + "_" + configKey))
+
+	flag.Usage += fmt.Sprintf(" (env var: %q)", envVar)
+
 	return nil
 }
 

--- a/quill/sign.go
+++ b/quill/sign.go
@@ -206,6 +206,7 @@ func signSingleBinary(cfg SigningConfig) error {
 	}
 
 	if cfg.SigningMaterial.Signer == nil {
+		bus.Notify("Warning: performed ad-hoc sign, which means that anyone can alter the binary contents without you knowing (there is no cryptographic signature)")
 		log.Warnf("only ad-hoc signing, which means that anyone can alter the binary contents without you knowing (there is no cryptographic signature)")
 	}
 


### PR DESCRIPTION
Shows `(env var: QUILL_...)` help hints for each attribute that supports taking values from the environment. For example:

```
$ quill sign --help
sign a macho (darwin) executable binary

Usage:
   sign PATH [flags]

Arguments:
  PATH:  the darwin binary to sign

Flags:
      --ad-hoc                    perform ad-hoc signing. No cryptographic signature is included and --p12 key and certificate input are not needed. Do NOT use this option for production builds. (env var: "QUILL_SIGN_AD_HOC")
  -h, --help                      help for sign
      --identity string           identifier to encode into the code directory of the code signing super block (default is derived from the name of the binary being solved) (env var: "QUILL_SIGN_OVERRIDE_IDENTITY")
      --p12 string                path to a PKCS12 file containing the private key, (leaf) signing certificate, remaining certificate chain. This can also be the base64-encoded contents of the p12 file, or 'env:ENV_VAR_NAME' to read the p12 from a different environment variable (env var: "QUILL_SIGN_P12")
      --timestamp-server string   URL to a timestamp server to use for timestamping the signature (env var: "QUILL_SIGN_TIMESTAMP_SERVER") (default "http://timestamp.apple.com/ts01")

```