### PR TITLE
Add release trigger workflow

### DIFF
--- a/.github/scripts/coverage.py
+++ b/.github/scripts/coverage.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import shlex
+
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+if len(sys.argv) < 3:
+    print("Usage: coverage.py [threshold] [go-coverage-report]")
+    sys.exit(1)
+
+
+threshold = float(sys.argv[1])
+report = sys.argv[2]
+
+
+args = shlex.split(f"go tool cover -func {report}")
+p = subprocess.run(args, capture_output=True, text=True)
+
+percent_coverage = float(p.stdout.splitlines()[-1].split()[-1].replace("%", ""))
+print(f"{bcolors.BOLD}Coverage: {percent_coverage}%{bcolors.ENDC}")
+
+if percent_coverage < threshold:
+    print(f"{bcolors.BOLD}{bcolors.FAIL}Coverage below threshold of {threshold}%{bcolors.ENDC}")
+    sys.exit(1)

--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if ! [ -x "$(command -v gh)" ]; then
+    echo "The GitHub CLI could not be found. To continue follow the instructions at https://github.com/cli/cli#installation"
+    exit 1
+fi
+
+gh auth status
+
+# we need all of the git state to determine the next version. Since tagging is done by
+# the release pipeline it is possible to not have all of the tags from previous releases.
+git fetch --tags
+
+# populates the CHANGELOG.md and VERSION files
+echo "${bold}Generating changelog...${normal}"
+make changelog 2> /dev/null
+
+NEXT_VERSION=$(cat VERSION)
+
+if [[ "$NEXT_VERSION" == "" ||  "${NEXT_VERSION}" == "(Unreleased)" ]]; then
+    echo "Could not determine the next version to release. Exiting..."
+    exit 1
+fi
+
+while true; do
+    read -p "${bold}Do you want to trigger a release for version '${NEXT_VERSION}'?${normal} [y/n] " yn
+    case $yn in
+        [Yy]* ) echo; break;;
+        [Nn]* ) echo; echo "Cancelling release..."; exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+echo "${bold}Kicking off release for ${NEXT_VERSION}${normal}..."
+echo
+gh workflow run release.yaml -f version=${NEXT_VERSION}
+
+echo
+echo "${bold}Waiting for release to start...${normal}"
+sleep 10
+
+set +e
+
+echo "${bold}Head to the release workflow to monitor the release:${normal} $(gh run list --workflow=release.yaml --limit=1 --json url --jq '.[].url')"
+id=$(gh run list --workflow=release.yaml --limit=1 --json databaseId --jq '.[].databaseId')
+gh run watch $id --exit-status || (echo ; echo "${bold}Logs of failed step:${normal}" && GH_PAGER="" gh run view $id --log-failed)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: ./.github/actions/bootstrap
 
       - name: Build & publish release artifacts
-        run: make release
+        run: make ci-release
         env:
           QUILL_SIGN_P12: ${{ secrets.APPLE_SIGNING_P12 }}
           QUILL_SIGN_PASSWORD: ${{ secrets.APPLE_SIGNING_P12_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 CHANGELOG.md
+VERSION
 /test/results
 /dist
 /snapshot

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,110 @@
+# Release
+
+## Creating a release
+
+This release process itself should be as automated as possible, and has only a few steps:
+
+1. **Trigger a new release with `make release`**. At this point you'll see a preview
+  changelog in the terminal. If you're happy with the changelog, press `y` to continue, otherwise
+  you can abort and adjust the labels on the PRs and issues to be included in the release and
+  re-run the release trigger command.
+
+1. A release admin must approve the release on the GitHub Actions release pipeline run page.
+   Once approved, the release pipeline will generate all assets and publish a GitHub Release.
+
+1. If there is a release Milestone, close it.
+
+Ideally releasing should be done often with small increments when possible. Unless a
+breaking change is blocking the release, or no fixes/features have been merged, a good
+target release cadence is between every 1 or 2 weeks.
+
+
+## Retracting a release
+
+If a release is found to be problematic, it can be retracted with the following steps:
+
+- Deleting the GitHub Release
+- Add a new `retract` entry in the go.mod for the versioned release
+
+**Note**: do not delete release tags from the git repository since there may already be references to the release
+in the go proxy, which will cause confusion when trying to reuse the tag later (the H1 hash will not match and there
+will be a warning when users try to pull the new release).
+
+
+## Background
+
+A good release process has the following qualities:
+
+1. There is a way to plan what should be in a release
+1. There is a way to see what is actually in a release
+1. Allow for different kinds of releases (major breaking vs backwards compatible enhancements vs patch updates)
+1. Specify a repeatable way to build and publish software artifacts
+
+
+### Planning a release
+
+To indicate a set of features to be released together add each issue to an in-repository
+Milestone named with major-minor version to be released (e.g. `v0.1`). It is OK for other
+features to be in the release that were not originally planned, and these issues and PRs
+do not need to be added to the Milestone in question. Only the set of features that, when
+completed, would allow the release to be considered complete. A Milestone is only used to:
+
+- Plan what is desired to be in a release
+- Track progress to indicate when we may be ready to cut a new release
+
+Not all releases need to be planned. For instance, patch releases for fixes should be
+released when they are ready and when releasing would not interfere with another current
+release (where some partial or breaking features have already been merged).
+
+Unless necessary, feature releases should be small and frequent, which may obviate the
+need for regular release planning under a Milestone.
+
+
+### What is in a release
+
+Milestones are specifically for planning a release, not necessarily tracking all changes
+that a release may bring (and more importantly, not all releases are necessarily planned
+either).
+
+This is one of the (many) reasons for a Changelog. A good Changelog lists changes grouped
+by the type of change (new, enhancement, deprecation, breaking, bug fix, security fix), in
+chronological order (within groups), linking the PR where the change was made in the
+Changelog line. Furthermore, there should be a place to see all released versions, the
+release date for each release, the semantic version of the release, and the set of changes
+for each release.
+
+**This project auto-generates the Changelog contents for each current release and posts the
+generated contents to the GitHub Release page**. Leveraging the GitHub Releases feature
+allows GitHub to manage the Changelog on each release outside of the git source tree while
+still being hosted with the released assets.
+
+The Changelog is generated from the metadata from in-repository issues and PRs, using
+labels to guide what kind of change each item is (e.g. breaking, new feature, bug fix,
+etc). Only issues/PRs with select labels are included in the Changelog, and only if the
+issue/PR was created after the last release. Additional labels are used to exclude items
+from the Changelog.
+
+The above suggestions imply that we should:
+
+- Ensure there is a sufficient title for each PR and issue title to be included in the
+  Changelog
+- The appropriate label is applied to PRs and/or issues to drive specific change type
+  sections (deprecated, breaking, security, bug, etc)
+
+**With this approach as we cultivate good organization of PRs and issues we automatically
+get an equally good Changelog.**
+
+
+### Major, minor, and patch releases
+
+The latest version of the tool is the only supported version, which implies that multiple
+parallel release branches will not be a regular process (if ever). Multiple releases can
+be planned in parallel, however, only one can be actively developed at a time. That is, if
+PRs attached to a release Milestone have been merged into the main branch, that release is
+now the "next" release. **This implies that the source of truth for release lies with the
+git log and Changelog, not with the release Milestones** (which are purely for planning and
+tracking).
+
+Semantic versioning should be used to indicate breaking changes, new features, and fixes.
+The exception to this is `< 1.0`, where the major version is not bumped for breaking changes,
+instead the minor version indicates both new features and breaking changes.


### PR DESCRIPTION
Adds the release trigger script + make targets as done in syft, grype, et. al.

In the process I noticed the coverage threshold was much lower than what's being tested now, so I bumped the threshold and updated the mechanism to the same as syft (coverage.py).

~Note: the target branch is the same as #39 , I'll update and rebase when that is merged.~