### PR TITLE
add oss community board auto-add workflow

### DIFF
--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,0 +1,16 @@
+name: Add to OSS board
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+      - labeled
+
+jobs:
+
+  run:
+    uses: "anchore/workflows/.github/workflows/oss-project-board-add.yaml@main"
+    secrets:
+      token: ${{ secrets.OSS_PROJECT_GH_TOKEN }}


### PR DESCRIPTION
Allows for automatically adding issues to the [OSS community board](https://github.com/orgs/anchore/projects/22)