### PR TITLE
Need capitalized http methods

### DIFF
--- a/quill/notary/http_client.go
+++ b/quill/notary/http_client.go
@@ -29,7 +29,7 @@ func newHTTPClient(token string, httpTimeout time.Duration) *httpClient {
 }
 
 func (s httpClient) get(ctx context.Context, endpoint string, body io.Reader) (*http.Response, error) {
-	request, err := http.NewRequest("get", endpoint, body)
+	request, err := http.NewRequest(http.MethodGet, endpoint, body)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (s httpClient) get(ctx context.Context, endpoint string, body io.Reader) (*
 }
 
 func (s httpClient) post(ctx context.Context, endpoint string, body io.Reader) (*http.Response, error) {
-	request, err := http.NewRequest("post", endpoint, body)
+	request, err := http.NewRequest(http.MethodPost, endpoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/quill/notary/http_client_test.go
+++ b/quill/notary/http_client_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_httpClient_get(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "get", r.Method)
+		assert.Equal(t, "GET", r.Method)
 		return
 	}))
 	defer s.Close()
@@ -27,7 +27,7 @@ func Test_httpClient_get(t *testing.T) {
 
 func Test_httpClient_post(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "post", r.Method)
+		assert.Equal(t, "POST", r.Method)
 		return
 	}))
 	defer s.Close()


### PR DESCRIPTION
Fixes #118 

Apple may have rolled out updated validation rules on incoming requests, one of them being ensure that HTTP verbs are capitalized.