### PR TITLE
fix: terminal clobbering

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -13,7 +13,7 @@ import (
 var log = discard.New()
 
 func Set(l logger.Logger) {
-	// though quill the application will automatically have a redaction logger, library consumers may not be doing this.
+	// though the application will automatically have a redaction logger, library consumers may not be doing this.
 	// for this reason we additionally ensure there is a redaction logger configured for any logger passed. The
 	// source of truth for redaction values is still in the internal redact package. If the passed logger is already
 	// redacted, then this is a no-op.


### PR DESCRIPTION
This PR applies the fix from https://github.com/anchore/grype/pull/1505 to avoid potential terminal clobbering