### PR TITLE
Update expired test fixtures

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.18.x"
+    default: "1.23.x"
   use-go-cache:
     description: "Restore go cache"
     required: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,10 @@
-# TODO: enable this when we have coverage on docstring comments
-#issues:
+issues:
+  max-same-issues: 25
+
+  # TODO: enable this when we have coverage on docstring comments
 #  # The list of ids of default excludes to include or disable.
 #  include:
 #    - EXC0002 # disable excluding of issues about comments from golint
-
-linters-settings:
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 80
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 60
 
 linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
@@ -21,10 +12,10 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gocognit
     - goconst
@@ -49,24 +40,51 @@ linters:
     - unused
     - whitespace
 
+linters-settings:
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 70
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 50
+  gocritic:
+    enabled-checks:
+      - deferInLoop
+      - ruleguard
+  gosec:
+    excludes:
+      - G115
+output:
+  uniq-by-line: false
+run:
+  timeout: 10m
+  tests: false
+
 # do not enable...
+#    - deadcode          # The owner seems to have abandoned the linter. Replaced by "unused".
+#    - depguard          # We don't have a configuration for this yet
+#    - goprintffuncname  # does not catch all cases and there are exceptions
+#    - nakedret          # does not catch all cases and should not fail a build
 #    - gochecknoglobals
 #    - gochecknoinits    # this is too aggressive
+#    - rowserrcheck disabled per generics https://github.com/golangci/golangci-lint/issues/2649
 #    - godot
 #    - godox
 #    - goerr113
-#    - golint       # deprecated
-#    - gomnd        # this is too aggressive
-#    - interfacer   # this is a good idea, but is no longer supported and is prone to false positives
-#    - lll          # without a way to specify per-line exception cases, this is not usable
-#    - maligned     # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
+#    - goimports   # we're using gosimports now instead to account for extra whitespaces (see https://github.com/golang/go/issues/20818)
+#    - golint      # deprecated
+#    - gomnd       # this is too aggressive
+#    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives
+#    - lll         # without a way to specify per-line exception cases, this is not usable
+#    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
 #    - nestif
 #    - prealloc     # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
+#    - rowserrcheck # not in a repo with sql, so this is not useful
 #    - scopelint    # deprecated
+#    - structcheck  # The owner seems to have abandoned the linter. Replaced by "unused".
 #    - testpackage
+#    - varcheck     # The owner seems to have abandoned the linter. Replaced by "unused".
 #    - wsl          # this doens't have an auto-fixer yet and is pretty noisy (https://github.com/bombsimon/wsl/issues/90)
-#    - varcheck     # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
-#    - deadcode     # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
-#    - structcheck  # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
-#    - rowserrcheck # we're not using sql.Rows at all in the codebase
-#    - depguard     # this requires additional configuration https://github.com/golangci/golangci-lint/issues/3877#issuecomment-1573760321

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ GLOW_CMD = $(TEMP_DIR)/glow
 
 # Tool versions #################################
 QUILL_VERSION = latest
-GOLANG_CI_VERSION = v1.57.2
+GOLANG_CI_VERSION = v1.61.0
 GOBOUNCER_VERSION = v0.4.0
-GORELEASER_VERSION = v1.17.0
+GORELEASER_VERSION = v2.3.2
 GOSIMPORTS_VERSION = v0.3.8
-CHRONICLE_VERSION = v0.6.0
+CHRONICLE_VERSION = v0.8.0
 GLOW_VERSION := v1.5.0
 
 # Formatting variables #################################
@@ -98,7 +98,7 @@ bootstrap-tools: $(TEMP_DIR)
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMP_DIR)/ $(CHRONICLE_VERSION)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ $(GOLANG_CI_VERSION)
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMP_DIR)/ $(GOBOUNCER_VERSION)
-	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
+	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@$(GOSIMPORTS_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/charmbracelet/glow@$(GLOW_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ COVER_TOTAL = $(RESULTS_DIR)/unit-coverage-summary.txt
 # Command templates #################################
 LINT_CMD = $(TEMP_DIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
 GOIMPORTS_CMD = $(TEMP_DIR)/gosimports -local github.com/anchore
-RELEASE_CMD = $(TEMP_DIR)/goreleaser release --rm-dist
-SNAPSHOT_CMD = $(RELEASE_CMD) --skip-publish --snapshot --skip-sign
+RELEASE_CMD = $(TEMP_DIR)/goreleaser release --clean
+SNAPSHOT_CMD = $(RELEASE_CMD) --clean --snapshot --skip=publish --skip=sign
 CHRONICLE_CMD = $(TEMP_DIR)/chronicle
 GLOW_CMD = $(TEMP_DIR)/glow
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SUCCESS := $(BOLD)$(GREEN)
 
 # Test variables #################################
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 45
+COVERAGE_THRESHOLD := 30
 
 ## Build variables #################################
 DIST_DIR = dist

--- a/internal/test/test-fixtures/assets/chain-ca-cert.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-cert.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da999b9ec7d54c3d897e51008a17f7811eee08ffa4e01f648c563cb12b540ecb
-size 3885
+oid sha256:7569430d5a11080450835e6a4c0ed2b3188e029f4a17ab6d248bdfea585bb52f
+size 4056

--- a/internal/test/test-fixtures/assets/chain-ca-csr.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-csr.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8ae4ee62c209de3ac7968de98fdb6dcb834ff57e92fc246aa6d78ad87a821b5
+oid sha256:418211b23df28b8042bb7613e11e1613e4f207396c74b8bc811f6eee2407ec70
 size 920

--- a/internal/test/test-fixtures/assets/chain-ca-int-cert.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-int-cert.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65d992c2b72b9354cd756f95ee6d359682715d71774fef04612fe34304428632
-size 3905
+oid sha256:bd8c7dbbdb00fb3e3ece8d8cf92d4d3bb4eed1f82664369f005794c5324c4dcb
+size 4243

--- a/internal/test/test-fixtures/assets/chain-ca-int-csr.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-int-csr.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:160b578bb68cbc9e76065ba5e5c04c4535eac8706aa68ce330486932339fcc69
+oid sha256:2382be24c1c7a672f5b28009951f45332cc894675e7cbb9604fb2cd1dfe182d6
 size 932

--- a/internal/test/test-fixtures/assets/chain-ca-int-key.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-int-key.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00d83ee98a421fb0188766e8fc119c9424beed6462d1a880b5d80ebd12a8e9c1
-size 1675
+oid sha256:e2f6a85323cab25b375f817cb2557091ab04350af8ca739d7eb9ff0818da116f
+size 1704

--- a/internal/test/test-fixtures/assets/chain-ca-key.pem
+++ b/internal/test/test-fixtures/assets/chain-ca-key.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d7b1e4cd9859e47ca4bcb526fa5c73181b4d2c18abef6ded86fc29e23a62a4c
-size 1679
+oid sha256:3676ceddd877c99415b7c2233bf28f1768693521a7d225729f4c49c61b6aa00d
+size 1704

--- a/internal/test/test-fixtures/assets/chain-leaf-cert.pem
+++ b/internal/test/test-fixtures/assets/chain-leaf-cert.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6f0a4fb3e1508e0839b182213dadcfe5a19b671189674dd1e43651a3398ccbf
-size 4044
+oid sha256:4c16565e2926b8e5fe03697c541bc23761d78342290ec0d8e52bb5715a970d10
+size 4229

--- a/internal/test/test-fixtures/assets/chain-leaf-csr.pem
+++ b/internal/test/test-fixtures/assets/chain-leaf-csr.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b6c3ad67776979ad775a9dd229be5b1d9439f1f18555dc4b65aca4c1ca50cc2
+oid sha256:854f392d771b82546f44a7211eac0bf30be6ce81e6dd16e38030789afdea9e7b
 size 1017

--- a/internal/test/test-fixtures/assets/chain-leaf-key.pem
+++ b/internal/test/test-fixtures/assets/chain-leaf-key.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30509b06fc653886f49440db3a5842173fb844b9821b189be4b9aa17c45ebb0a
-size 1679
+oid sha256:19444be533bbe96414e958391e2295afaddeb14b927c2d6b161d1f2e1ba580e6
+size 1704

--- a/internal/test/test-fixtures/assets/chain.p12
+++ b/internal/test/test-fixtures/assets/chain.p12
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d4abb1b91fe8f1bc26465bb91dc28e452d481380a68204e03f2552f20f38dd8
-size 3997
+oid sha256:527c2a660d154e0823c52819dc3d33a26e486a5c7f1c609db18d5e48a8531c94
+size 4291

--- a/internal/test/test-fixtures/assets/chain.pem
+++ b/internal/test/test-fixtures/assets/chain.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7dd0d57b9c68adbfae07e13877f3568d2e9707d5a7ddddc96ce861237c09887
-size 11834
+oid sha256:ccf780943c06ba32a7e66ed8bb0b21a60fed92bca615ac3b068584379f32fabc
+size 12528

--- a/internal/test/test-fixtures/assets/x509-cert.pem
+++ b/internal/test/test-fixtures/assets/x509-cert.pem
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a25061f5ab617b026fb7d53dc908239134b76fcf16a0cec7eec408e37576806d
-size 1708
+oid sha256:aae0d313da36ab2117d8019255227aa28f62a61e1017f5f5e77cb335a02a249b
+size 1367

--- a/internal/test/test-fixtures/fixture-chain/intermediate_ca/index
+++ b/internal/test/test-fixtures/fixture-chain/intermediate_ca/index
@@ -1,1 +1,1 @@
-V	240802160335Z		00	unknown	/CN=quill-test-leaf
+V	270114130949Z		00	unknown	/CN=quill-test-leaf

--- a/internal/test/test-fixtures/fixture-chain/root_ca/index
+++ b/internal/test/test-fixtures/fixture-chain/root_ca/index
@@ -1,2 +1,2 @@
-V	240802160335Z		00	unknown	/C=US/CN=quill-test-root-ca
-V	240802160335Z		01	unknown	/C=US/CN=quill-test-intermediate-ca
+V	270114130949Z		00	unknown	/C=US/CN=quill-test-root-ca
+V	270114130949Z		01	unknown	/C=US/CN=quill-test-intermediate-ca

--- a/internal/test/test-fixtures/fixture-chain/root_ca/index.old
+++ b/internal/test/test-fixtures/fixture-chain/root_ca/index.old
@@ -1,1 +1,1 @@
-V	240802160335Z		00	unknown	/C=US/CN=quill-test-root-ca
+V	270114130949Z		00	unknown	/C=US/CN=quill-test-root-ca

--- a/internal/test/test-fixtures/fixture-chain/store/00.pem
+++ b/internal/test/test-fixtures/fixture-chain/store/00.pem
@@ -1,35 +1,35 @@
 Certificate:
     Data:
-        Version: 1 (0x0)
+        Version: 3 (0x2)
         Serial Number: 0 (0x0)
-    Signature Algorithm: sha256WithRSAEncryption
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, CN=quill-test-intermediate-ca
         Validity
-            Not Before: Apr 30 16:03:35 2022 GMT
-            Not After : Aug  2 16:03:35 2024 GMT
+            Not Before: Oct 11 13:09:49 2024 GMT
+            Not After : Jan 14 13:09:49 2027 GMT
         Subject: CN=quill-test-leaf
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:b8:a3:a2:86:62:09:c3:84:3a:78:cf:7b:3c:4a:
-                    2a:e3:88:ac:93:4e:58:5a:7a:de:fc:d5:11:fe:8d:
-                    74:a7:97:16:ff:1a:5e:0b:6b:6d:68:1d:58:28:e7:
-                    bb:e4:30:91:5b:f0:df:70:e3:b7:64:e0:05:b4:5b:
-                    cf:87:a0:40:ae:88:2e:ff:c1:96:96:9d:ac:12:1e:
-                    bb:63:cf:cd:97:4d:77:e0:9a:c9:d2:e4:fd:93:94:
-                    fc:f3:d1:c3:43:27:6b:d1:8f:52:70:50:98:93:2f:
-                    eb:16:8a:2f:20:4e:a9:0b:06:ca:34:b7:45:c5:de:
-                    42:9b:31:60:a7:16:eb:52:f3:f8:bd:04:c5:eb:c4:
-                    fe:02:ab:38:a9:e6:b5:9b:4c:89:10:1f:ac:c2:80:
-                    1f:76:b8:fb:f5:b0:7a:28:01:a5:c4:8c:bd:5e:b6:
-                    90:f1:60:5f:52:1e:d2:66:71:93:0a:83:04:d9:0e:
-                    39:de:4c:c8:2e:63:4d:cc:a7:ae:5a:3f:f7:67:22:
-                    c0:d4:45:29:98:3f:cf:e1:ae:4e:e4:cf:62:0d:48:
-                    a9:5d:66:a8:f4:cf:e9:67:19:83:85:b0:27:cb:0d:
-                    b8:00:28:49:83:74:19:a5:40:2b:ad:97:c8:af:f5:
-                    9e:76:e9:a3:00:5c:e2:78:ef:a2:80:08:04:4b:42:
-                    da:69
+                    00:c2:38:1b:70:a7:7b:45:eb:e8:f4:13:db:43:5c:
+                    f9:75:d6:4c:3d:a7:9c:33:a5:6f:62:2c:95:26:78:
+                    e3:44:73:09:89:9e:40:ae:64:ef:d2:43:fe:b9:9b:
+                    bb:ad:56:81:2e:3d:1c:78:da:64:b2:76:fe:6c:9c:
+                    85:89:c4:a2:9f:2f:fa:63:85:2e:26:a7:72:52:75:
+                    5b:7b:98:0d:69:c3:cb:54:1b:a1:7b:27:ce:51:b2:
+                    c8:c0:1b:be:91:fa:28:c7:0e:16:a4:75:14:1b:ce:
+                    a3:da:5c:0b:95:b7:f7:86:01:6b:08:8e:5c:88:db:
+                    3d:be:38:03:0f:58:30:9e:2a:45:9e:94:71:f0:07:
+                    96:6d:67:e6:e7:44:e2:f9:53:97:e8:74:a1:c1:1c:
+                    30:c3:45:e6:6a:a7:cb:2c:1c:56:68:76:1c:0c:fa:
+                    e4:e1:ba:e4:6a:c3:de:66:77:3d:3f:70:31:07:85:
+                    9b:50:e7:c1:c8:cb:6d:b6:8e:26:bc:72:05:67:82:
+                    58:69:58:cf:37:32:2f:ea:f5:63:6b:2b:f6:a8:bc:
+                    0d:42:9a:e0:a0:99:2f:ff:b2:e4:7f:44:a8:d3:2a:
+                    6e:d7:8a:ed:b8:89:b4:c0:bc:2c:44:57:4b:1c:ea:
+                    ca:d1:15:ab:44:56:16:6a:cd:e9:ea:2f:5e:99:18:
+                    8b:9d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Key Usage: critical
@@ -37,39 +37,43 @@ Certificate:
             X509v3 Extended Key Usage: critical
                 Code Signing
             X509v3 Subject Key Identifier: 
-                B4:E9:5B:CF:BF:9A:C6:CA:61:B9:15:F3:CE:89:51:F6:FD:27:F4:8F
+                BF:2D:67:4C:31:EE:C3:F3:58:38:C6:AF:3F:BA:7E:A8:CB:69:5E:1E
+            X509v3 Authority Key Identifier: 
+                1C:DD:F1:37:6F:0C:65:8B:3B:92:45:35:01:70:C4:93:B5:23:E1:CA
     Signature Algorithm: sha256WithRSAEncryption
-         41:88:e8:63:85:86:19:46:ef:f3:f4:ee:ba:a6:94:8a:e5:90:
-         f5:25:cc:be:34:0c:88:af:83:ca:6c:01:d5:a3:cd:10:6e:70:
-         0b:66:2c:fc:ca:f9:cb:32:c8:9a:39:9c:95:11:85:f6:64:a9:
-         24:49:f3:37:4d:ad:22:e0:32:c5:0a:fe:37:72:da:4f:57:67:
-         43:30:79:63:74:2c:0f:86:3f:20:07:d7:77:c2:a7:2c:79:8b:
-         f7:01:94:cd:a0:97:16:63:a4:52:94:b7:7f:5a:83:1c:2d:40:
-         ed:7e:53:ba:85:e9:fb:6a:91:22:e1:88:51:32:71:4a:77:ae:
-         98:c7:a4:38:01:11:2c:8a:b4:2a:65:05:91:30:67:60:2c:cc:
-         4b:87:b2:e6:3d:b2:d4:2c:14:b4:b2:72:b2:a1:70:3a:48:2c:
-         2b:20:f4:37:ef:fc:26:eb:12:dd:9b:46:66:4e:1e:7d:26:4b:
-         57:b3:7c:da:a8:53:5a:d8:52:5f:e8:82:df:6a:f1:d1:87:8b:
-         24:2c:bd:a8:b7:2c:27:3d:4c:bc:85:ed:f0:1a:40:55:92:e7:
-         de:86:14:38:a5:e6:39:99:7d:0d:a5:c6:ba:5c:a7:b1:3b:8c:
-         01:9f:21:84:d3:7b:ce:80:2c:f0:f8:2f:3a:6d:ca:de:23:ba:
-         75:bf:71:ba
+    Signature Value:
+        c5:81:46:fd:52:ae:b9:49:b9:3e:4c:0a:35:3d:87:d8:49:66:
+        e0:ea:b4:d3:f9:03:75:98:0b:38:e9:d9:3c:f5:77:eb:8d:c2:
+        99:77:86:c8:b3:70:95:89:49:80:12:28:12:e0:eb:ec:1d:86:
+        67:3a:24:62:dc:66:47:61:88:54:e4:26:a0:5a:40:95:b3:bd:
+        f5:af:04:3d:21:da:dd:08:ee:a3:1d:4b:77:ff:96:ce:ed:47:
+        52:63:f5:a7:aa:9e:06:6b:5f:d4:14:88:5f:a4:4c:4a:d3:94:
+        50:dc:32:fd:25:ff:51:7b:f8:db:6a:2a:ce:a8:b8:dd:7e:c9:
+        2e:ac:ea:06:fe:3b:ca:c2:ba:bc:1d:6f:92:b6:f8:52:7c:48:
+        58:ca:35:86:99:65:eb:0a:65:00:8d:1a:c0:61:89:37:06:d8:
+        c7:d8:39:7a:67:fa:4b:f5:ae:a6:d4:f4:38:40:39:0d:c3:30:
+        41:7a:88:7e:b6:d7:ee:ec:f8:99:fa:44:0f:63:b1:e2:d6:b3:
+        9f:ec:7d:cf:12:3d:74:5c:94:2b:d6:5a:3a:eb:81:d5:40:2f:
+        96:6b:88:bc:e1:d0:63:da:fd:7c:ae:21:5a:c5:15:1e:6c:6c:
+        10:80:12:59:52:18:f9:0e:b3:f8:cf:55:4d:8d:b5:13:0f:98:
+        35:18:26:da
 -----BEGIN CERTIFICATE-----
-MIIDCzCCAfMCAQAwDQYJKoZIhvcNAQELBQAwMjELMAkGA1UEBhMCVVMxIzAhBgNV
-BAMMGnF1aWxsLXRlc3QtaW50ZXJtZWRpYXRlLWNhMB4XDTIyMDQzMDE2MDMzNVoX
-DTI0MDgwMjE2MDMzNVowGjEYMBYGA1UEAwwPcXVpbGwtdGVzdC1sZWFmMIIBIjAN
-BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuKOihmIJw4Q6eM97PEoq44isk05Y
-Wnre/NUR/o10p5cW/xpeC2ttaB1YKOe75DCRW/DfcOO3ZOAFtFvPh6BArogu/8GW
-lp2sEh67Y8/Nl0134JrJ0uT9k5T889HDQydr0Y9ScFCYky/rFoovIE6pCwbKNLdF
-xd5CmzFgpxbrUvP4vQTF68T+Aqs4qea1m0yJEB+swoAfdrj79bB6KAGlxIy9XraQ
-8WBfUh7SZnGTCoME2Q453kzILmNNzKeuWj/3ZyLA1EUpmD/P4a5O5M9iDUipXWao
-9M/pZxmDhbAnyw24AChJg3QZpUArrZfIr/WedumjAFzieO+igAgES0LaaQIDAQAB
-o0kwRzAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwMwHQYD
-VR0OBBYEFLTpW8+/msbKYbkV886JUfb9J/SPMA0GCSqGSIb3DQEBCwUAA4IBAQBB
-iOhjhYYZRu/z9O66ppSK5ZD1Jcy+NAyIr4PKbAHVo80QbnALZiz8yvnLMsiaOZyV
-EYX2ZKkkSfM3Ta0i4DLFCv43ctpPV2dDMHljdCwPhj8gB9d3wqcseYv3AZTNoJcW
-Y6RSlLd/WoMcLUDtflO6hen7apEi4YhRMnFKd66Yx6Q4AREsirQqZQWRMGdgLMxL
-h7LmPbLULBS0snKyoXA6SCwrIPQ37/wm6xLdm0ZmTh59JktXs3zaqFNa2FJf6ILf
-avHRh4skLL2otywnPUy8he3wGkBVkufehhQ4peY5mX0Npca6XKexO4wBnyGE03vO
-gCzw+C86bcreI7p1v3G6
+MIIDMTCCAhmgAwIBAgIBADANBgkqhkiG9w0BAQsFADAyMQswCQYDVQQGEwJVUzEj
+MCEGA1UEAwwacXVpbGwtdGVzdC1pbnRlcm1lZGlhdGUtY2EwHhcNMjQxMDExMTMw
+OTQ5WhcNMjcwMTE0MTMwOTQ5WjAaMRgwFgYDVQQDDA9xdWlsbC10ZXN0LWxlYWYw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCOBtwp3tF6+j0E9tDXPl1
+1kw9p5wzpW9iLJUmeONEcwmJnkCuZO/SQ/65m7utVoEuPRx42mSydv5snIWJxKKf
+L/pjhS4mp3JSdVt7mA1pw8tUG6F7J85RssjAG76R+ijHDhakdRQbzqPaXAuVt/eG
+AWsIjlyI2z2+OAMPWDCeKkWelHHwB5ZtZ+bnROL5U5fodKHBHDDDReZqp8ssHFZo
+dhwM+uThuuRqw95mdz0/cDEHhZtQ58HIy222jia8cgVnglhpWM83Mi/q9WNrK/ao
+vA1CmuCgmS//suR/RKjTKm7Xiu24ibTAvCxEV0sc6srRFatEVhZqzenqL16ZGIud
+AgMBAAGjajBoMA4GA1UdDwEB/wQEAwIHgDAWBgNVHSUBAf8EDDAKBggrBgEFBQcD
+AzAdBgNVHQ4EFgQUvy1nTDHuw/NYOMavP7p+qMtpXh4wHwYDVR0jBBgwFoAUHN3x
+N28MZYs7kkU1AXDEk7Uj4cowDQYJKoZIhvcNAQELBQADggEBAMWBRv1SrrlJuT5M
+CjU9h9hJZuDqtNP5A3WYCzjp2Tz1d+uNwpl3hsizcJWJSYASKBLg6+wdhmc6JGLc
+ZkdhiFTkJqBaQJWzvfWvBD0h2t0I7qMdS3f/ls7tR1Jj9aeqngZrX9QUiF+kTErT
+lFDcMv0l/1F7+NtqKs6ouN1+yS6s6gb+O8rCurwdb5K2+FJ8SFjKNYaZZesKZQCN
+GsBhiTcG2MfYOXpn+kv1rqbU9DhAOQ3DMEF6iH621+7s+Jn6RA9jseLWs5/sfc8S
+PXRclCvWWjrrgdVAL5ZriLzh0GPa/XyuIVrFFR5sbBCAEllSGPkOs/jPVU2NtRMP
+mDUYJto=
 -----END CERTIFICATE-----

--- a/internal/test/test-fixtures/fixture-chain/store/01.pem
+++ b/internal/test/test-fixtures/fixture-chain/store/01.pem
@@ -2,71 +2,78 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number: 1 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, CN=quill-test-root-ca
         Validity
-            Not Before: Apr 30 16:03:35 2022 GMT
-            Not After : Aug  2 16:03:35 2024 GMT
+            Not Before: Oct 11 13:09:49 2024 GMT
+            Not After : Jan 14 13:09:49 2027 GMT
         Subject: C=US, CN=quill-test-intermediate-ca
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:bf:89:23:e0:22:d9:1b:b6:7f:c8:75:dc:e9:eb:
-                    99:08:2f:d6:d2:da:53:8a:17:fd:dc:0b:da:14:6c:
-                    bb:e4:db:87:5d:ac:e0:e0:37:2f:2b:f3:44:59:15:
-                    2a:6a:e3:ec:60:78:b8:ca:99:a1:91:72:b3:e1:e8:
-                    31:eb:6e:1f:78:72:8e:ed:51:65:61:2c:bf:21:91:
-                    ea:38:b3:b3:ca:81:f0:ba:fd:c2:ff:80:2c:52:d6:
-                    f4:7b:e2:fe:bb:b7:8a:90:3c:66:e1:7e:4e:86:6a:
-                    2d:fa:67:0e:e3:da:04:71:96:40:74:42:c9:08:84:
-                    11:f4:bd:58:f0:d1:73:6c:c1:47:74:e5:2a:5f:12:
-                    b0:b5:f4:85:b1:09:2f:3e:a2:8b:25:0e:d4:49:ec:
-                    84:0d:e5:27:14:d0:7f:d7:fc:6c:58:e6:e5:d7:29:
-                    41:9b:e0:08:ce:70:1c:ef:d7:cc:93:55:06:53:fc:
-                    a7:f6:d4:f4:fc:c7:86:22:c6:aa:c5:7a:c7:16:e5:
-                    9c:cb:f8:fd:5d:12:0e:72:ba:fb:f0:6f:1d:8e:02:
-                    1b:dc:72:b9:a6:5f:3a:32:e9:7f:06:70:07:78:b3:
-                    f9:ae:b5:3a:e8:e8:0a:66:6a:ae:eb:fd:78:af:35:
-                    e0:2b:c4:7e:b2:f2:07:c2:8c:60:24:73:68:33:72:
-                    5c:47
+                    00:e7:87:a8:73:c2:a4:bd:5b:9a:48:03:6e:c3:93:
+                    a8:de:87:b3:32:57:28:57:e2:7b:31:23:e0:a4:bf:
+                    2f:81:05:de:51:ba:23:97:6e:d7:56:f6:34:5d:41:
+                    44:06:ad:db:48:cc:3c:11:31:52:3b:9a:60:5d:83:
+                    a7:89:48:19:d9:3e:8d:09:ba:0e:26:4c:fb:54:84:
+                    b3:ca:c1:e2:62:aa:00:89:c2:bb:68:17:d8:72:ba:
+                    18:54:a3:45:a0:0e:5b:7b:13:cd:20:e1:33:70:43:
+                    5b:22:58:36:94:c6:c8:0d:1a:98:d5:40:de:b4:94:
+                    5e:fa:9e:c3:67:20:1b:f5:81:ce:93:ef:ac:2d:07:
+                    52:ba:e9:7b:d4:1e:3a:cb:25:aa:e4:7e:86:3b:f7:
+                    3c:2f:a1:41:30:e1:3a:92:e3:ae:5b:b8:5f:38:06:
+                    52:e8:29:e7:82:b3:2b:01:6b:a2:56:f0:08:fd:bc:
+                    fb:af:12:c3:7c:88:7c:76:58:e0:88:c2:17:d5:3a:
+                    2a:19:cb:b8:3b:ef:95:6d:db:68:44:a2:21:e3:03:
+                    2e:4a:2f:7e:72:6c:55:f9:07:43:c9:e0:7b:d2:04:
+                    85:e0:f5:36:74:3e:7a:0e:61:55:e2:42:fb:9d:49:
+                    44:93:da:16:87:6c:3e:ba:da:e0:02:42:38:72:5e:
+                    29:c1
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
                 CA:TRUE
             X509v3 Key Usage: critical
                 Certificate Sign
+            X509v3 Subject Key Identifier: 
+                1C:DD:F1:37:6F:0C:65:8B:3B:92:45:35:01:70:C4:93:B5:23:E1:CA
+            X509v3 Authority Key Identifier: 
+                C8:CE:D1:2B:0E:65:C8:D7:43:55:69:F1:49:99:26:97:1F:D4:32:39
     Signature Algorithm: sha256WithRSAEncryption
-         bf:07:1c:d1:0d:9c:7f:fa:a7:31:63:23:62:d5:0e:06:d2:cc:
-         20:a0:42:d9:1c:19:a8:25:b1:be:d8:7c:3a:07:2b:a4:f6:ff:
-         cd:ab:f5:21:03:ba:ee:a3:1b:bf:d2:9a:43:bc:68:67:8b:26:
-         f6:af:06:5b:b5:e2:bb:dc:3b:4b:e2:25:59:aa:70:3b:56:55:
-         8a:0d:88:a5:0e:63:c0:07:53:57:75:7f:59:3c:64:56:69:a5:
-         53:54:6d:4c:4b:bd:3f:7d:27:0a:e7:60:e9:b7:44:62:8e:ae:
-         cb:a3:d3:2e:cd:a8:bc:d2:c2:c9:bc:7e:c3:5c:23:16:80:87:
-         58:ef:f9:97:2f:5a:af:ec:6b:71:59:3e:c6:8f:d6:05:84:8e:
-         fb:9c:4b:ec:c5:12:7b:85:a0:b8:e8:de:83:7c:46:3a:0d:51:
-         31:c5:95:aa:94:8e:5d:44:5b:9a:28:38:aa:ff:8b:ba:77:e3:
-         42:57:08:03:79:e0:b3:d7:4d:cd:7e:04:25:f8:76:6c:a4:fd:
-         ad:53:bc:18:32:5c:86:ef:1d:bb:9b:ce:2f:c3:2b:5e:fd:77:
-         06:6e:36:5e:db:7f:f6:df:df:95:7f:1c:6d:49:6b:eb:cc:08:
-         3a:89:98:37:8e:e3:d4:24:b4:de:a2:22:ec:f6:71:47:94:0d:
-         ab:0b:1f:c0
+    Signature Value:
+        2b:8b:43:6b:ce:cd:75:70:6d:e9:2c:be:c6:b2:85:58:dd:e4:
+        09:fe:85:d9:88:3d:03:b8:66:86:7c:23:38:c7:31:25:33:95:
+        aa:84:7d:99:75:09:8f:5d:39:ea:11:2c:65:1d:39:f5:e2:d5:
+        16:ed:08:47:61:89:a9:b1:f7:6a:c3:24:45:e2:b9:c5:00:2d:
+        cb:4d:39:0f:05:b5:f1:3f:04:c8:8b:b5:34:bf:a4:c3:ef:e6:
+        9c:a6:c0:9b:c8:f8:6f:24:bb:50:f2:4c:8d:53:d5:71:dc:71:
+        87:c5:b9:39:07:ef:47:4b:1f:15:d8:f3:7b:a0:5b:75:34:67:
+        f8:51:a8:17:33:31:37:82:89:65:e6:9e:fc:a5:65:9f:f7:f2:
+        9c:12:1c:6e:a0:74:e4:0c:69:c3:31:33:c3:bc:3e:2b:84:8a:
+        0e:b3:4f:ae:e0:38:ea:d0:78:6b:c4:2a:9e:2e:c8:e1:af:1c:
+        32:e8:55:40:b7:91:cf:84:1d:4d:87:2c:26:a2:19:46:32:bc:
+        a6:10:d6:e6:fd:6e:51:97:0c:31:68:53:bc:75:ab:2b:f2:9c:
+        c4:75:b9:0b:24:e8:52:70:c1:4c:e3:49:9c:6f:7b:50:4f:f2:
+        30:7f:8f:e5:0d:56:64:fb:50:cb:7d:2e:6d:c9:d3:6e:74:bf:
+        9c:5e:6f:ab
 -----BEGIN CERTIFICATE-----
-MIIC+jCCAeKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAqMQswCQYDVQQGEwJVUzEb
-MBkGA1UEAwwScXVpbGwtdGVzdC1yb290LWNhMB4XDTIyMDQzMDE2MDMzNVoXDTI0
-MDgwMjE2MDMzNVowMjELMAkGA1UEBhMCVVMxIzAhBgNVBAMMGnF1aWxsLXRlc3Qt
+MIIDOjCCAiKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAqMQswCQYDVQQGEwJVUzEb
+MBkGA1UEAwwScXVpbGwtdGVzdC1yb290LWNhMB4XDTI0MTAxMTEzMDk0OVoXDTI3
+MDExNDEzMDk0OVowMjELMAkGA1UEBhMCVVMxIzAhBgNVBAMMGnF1aWxsLXRlc3Qt
 aW50ZXJtZWRpYXRlLWNhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
-v4kj4CLZG7Z/yHXc6euZCC/W0tpTihf93AvaFGy75NuHXazg4DcvK/NEWRUqauPs
-YHi4ypmhkXKz4egx624feHKO7VFlYSy/IZHqOLOzyoHwuv3C/4AsUtb0e+L+u7eK
-kDxm4X5Ohmot+mcO49oEcZZAdELJCIQR9L1Y8NFzbMFHdOUqXxKwtfSFsQkvPqKL
-JQ7USeyEDeUnFNB/1/xsWObl1ylBm+AIznAc79fMk1UGU/yn9tT0/MeGIsaqxXrH
-FuWcy/j9XRIOcrr78G8djgIb3HK5pl86Mul/BnAHeLP5rrU66OgKZmqu6/14rzXg
-K8R+svIHwoxgJHNoM3JcRwIDAQABoyMwITAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
-DwEB/wQEAwICBDANBgkqhkiG9w0BAQsFAAOCAQEAvwcc0Q2cf/qnMWMjYtUOBtLM
-IKBC2RwZqCWxvth8OgcrpPb/zav1IQO67qMbv9KaQ7xoZ4sm9q8GW7Xiu9w7S+Il
-WapwO1ZVig2IpQ5jwAdTV3V/WTxkVmmlU1RtTEu9P30nCudg6bdEYo6uy6PTLs2o
-vNLCybx+w1wjFoCHWO/5ly9ar+xrcVk+xo/WBYSO+5xL7MUSe4WguOjeg3xGOg1R
-McWVqpSOXURbmig4qv+LunfjQlcIA3ngs9dNzX4EJfh2bKT9rVO8GDJchu8du5vO
-L8MrXv13Bm42Xtt/9t/flX8cbUlr68wIOomYN47j1CS03qIi7PZxR5QNqwsfwA==
+54eoc8KkvVuaSANuw5Oo3oezMlcoV+J7MSPgpL8vgQXeUbojl27XVvY0XUFEBq3b
+SMw8ETFSO5pgXYOniUgZ2T6NCboOJkz7VISzysHiYqoAicK7aBfYcroYVKNFoA5b
+exPNIOEzcENbIlg2lMbIDRqY1UDetJRe+p7DZyAb9YHOk++sLQdSuul71B46yyWq
+5H6GO/c8L6FBMOE6kuOuW7hfOAZS6CnngrMrAWuiVvAI/bz7rxLDfIh8dljgiMIX
+1ToqGcu4O++VbdtoRKIh4wMuSi9+cmxV+QdDyeB70gSF4PU2dD56DmFV4kL7nUlE
+k9oWh2w+utrgAkI4cl4pwQIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
+DwEB/wQEAwICBDAdBgNVHQ4EFgQUHN3xN28MZYs7kkU1AXDEk7Uj4cowHwYDVR0j
+BBgwFoAUyM7RKw5lyNdDVWnxSZkmlx/UMjkwDQYJKoZIhvcNAQELBQADggEBACuL
+Q2vOzXVwbeksvsayhVjd5An+hdmIPQO4ZoZ8IzjHMSUzlaqEfZl1CY9dOeoRLGUd
+OfXi1RbtCEdhiamx92rDJEXiucUALctNOQ8FtfE/BMiLtTS/pMPv5pymwJvI+G8k
+u1DyTI1T1XHccYfFuTkH70dLHxXY83ugW3U0Z/hRqBczMTeCiWXmnvylZZ/38pwS
+HG6gdOQMacMxM8O8PiuEig6zT67gOOrQeGvEKp4uyOGvHDLoVUC3kc+EHU2HLCai
+GUYyvKYQ1ub9blGXDDFoU7x1qyvynMR1uQsk6FJwwUzjSZxve1BP8jB/j+UNVmT7
+UMt9Lm3J0250v5xeb6s=
 -----END CERTIFICATE-----

--- a/internal/test/test-fixtures/fixture-x509/Makefile
+++ b/internal/test/test-fixtures/fixture-x509/Makefile
@@ -62,11 +62,10 @@ $(CERT_FILE): $(KEY_FILE) $(CA_KEY_FILE) $(CA_CERT_FILE) $(DOMAIN_FILE) ## creat
 	# create the certificate
 	openssl x509 \
 		-req \
-		-days 10000 \
+		-days 100000 \
 		-in $(CSR_FILE) \
 		-signkey $(KEY_FILE) \
 		-out $(CERT_FILE) \
-		-CA $(CA_CERT_FILE) \
 		-CAkey $(CA_KEY_FILE) \
 		-extfile $(DOMAIN_FILE) \
 		-CAcreateserial \
@@ -95,7 +94,7 @@ $(CA_CERT_FILE): $(CA_KEY_FILE) $(DOMAIN_FILE) ## create a self-signed certifica
 	# create the certificate
 	openssl x509 \
 		-req \
-		-days 10000 \
+		-days 100000 \
 		-in $(CA_CSR_FILE) \
 		-signkey $(CA_KEY_FILE) \
 		-out $(CA_CERT_FILE) \

--- a/quill/notary/submission.go
+++ b/quill/notary/submission.go
@@ -2,10 +2,9 @@ package notary
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"path/filepath"
-	"time"
 
 	"github.com/anchore/quill/internal/log"
 )
@@ -143,8 +142,7 @@ func (s Submission) List(ctx context.Context) ([]SubmissionList, error) {
 }
 
 func randomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, length)
-	rand.Read(b) //nolint:gosec
+	_, _ = rand.Read(b)
 	return fmt.Sprintf("%x", b)[:length]
 }

--- a/quill/pki/certchain/find_test.go
+++ b/quill/pki/certchain/find_test.go
@@ -60,9 +60,8 @@ func TestFindRemainingChainCertsWithinQuill(t *testing.T) {
 				"quill-test-root-ca",
 			},
 			wantKeyIds: []string{
-				// test fixture has no id's (other than the leaf)
-				"",
-				"",
+				"1cddf1376f0c658b3b9245350170c493b523e1ca",
+				"c8ced12b0e65c8d7435569f1499926971fd43239",
 			},
 		},
 		{
@@ -136,8 +135,7 @@ func TestFindRemainingChainCertsWithinQuill(t *testing.T) {
 				"quill-test-intermediate-ca",
 			},
 			wantKeyIds: []string{
-				// test fixture has no id's (other than the leaf)
-				"",
+				"1cddf1376f0c658b3b9245350170c493b523e1ca",
 			},
 			wantErr: require.Error,
 		},

--- a/quill/sign_test.go
+++ b/quill/sign_test.go
@@ -137,10 +137,10 @@ func TestSign(t *testing.T) {
 			assertions: []test.OutputAssertion{
 				test.AssertContains("CodeDirectory v=20500 size=208904 flags=0x10000(runtime) hashes=6523+2 location=embedded"),
 				test.AssertContains("Hash type=sha256 size=32"),
-				test.AssertContains("CandidateCDHash sha256=d7273a0be24e8badeae7de4b7979418e82862ca5"),
-				test.AssertContains("CandidateCDHashFull sha256=d7273a0be24e8badeae7de4b7979418e82862ca5b9998d25927d33ba1b827fc6"),
-				test.AssertContains("CDHash=d7273a0be24e8badeae7de4b7979418e82862ca5"),
-				test.AssertContains("CMSDigest=d7273a0be24e8badeae7de4b7979418e82862ca5b9998d25927d33ba1b827fc6"),
+				test.AssertContains("CandidateCDHash sha256=f08da6b0d99061c280b0c530648896f0f0cf5625"),
+				test.AssertContains("CandidateCDHashFull sha256=f08da6b0d99061c280b0c530648896f0f0cf562527cbf1e2cebfc514452a24c3"),
+				test.AssertContains("CDHash=f08da6b0d99061c280b0c530648896f0f0cf5625"),
+				test.AssertContains("CMSDigest=f08da6b0d99061c280b0c530648896f0f0cf562527cbf1e2cebfc514452a24c3"),
 				test.AssertContains("CMSDigestType=2"),
 				test.AssertContains("Signature size="), // assert not adhoc
 				test.AssertContains("Authority=quill-test-leaf"),
@@ -165,10 +165,10 @@ func TestSign(t *testing.T) {
 			assertions: []test.OutputAssertion{
 				test.AssertContains("CodeDirectory v=20500 size=208904 flags=0x10000(runtime) hashes=6523+2 location=embedded"),
 				test.AssertContains("Hash type=sha256 size=32"),
-				test.AssertContains("CandidateCDHash sha256=a1c1c60573a81e780c5cd11d3b17b252291a5739"),
-				test.AssertContains("CandidateCDHashFull sha256=a1c1c60573a81e780c5cd11d3b17b252291a573915fa47e8927a00b1a877af1c"),
-				test.AssertContains("CDHash=a1c1c60573a81e780c5cd11d3b17b252291a5739"),
-				test.AssertContains("CMSDigest=a1c1c60573a81e780c5cd11d3b17b252291a573915fa47e8927a00b1a877af1c"),
+				test.AssertContains("CandidateCDHash sha256=6ff0e1e29bc047b941d768a1cf4cd38adcdda30a"),
+				test.AssertContains("CandidateCDHashFull sha256=6ff0e1e29bc047b941d768a1cf4cd38adcdda30aaf879f0b6b77654e2e4f3261"),
+				test.AssertContains("CDHash=6ff0e1e29bc047b941d768a1cf4cd38adcdda30a"),
+				test.AssertContains("CMSDigest=6ff0e1e29bc047b941d768a1cf4cd38adcdda30aaf879f0b6b77654e2e4f3261"),
 				test.AssertContains("CMSDigestType=2"),
 				test.AssertContains("Signature size="),         // assert not adhoc
 				test.AssertContains("Authority=(unavailable)"), // since the cert is not trusted by the system
@@ -190,12 +190,12 @@ func TestSign(t *testing.T) {
 				failWithoutFullChain: true,
 			},
 			assertions: []test.OutputAssertion{
-				test.AssertContains("CodeDirectory v=20500 size=643 flags=0x10000(runtime) hashes=15+2 location=embedded"),
+				test.AssertContains("CodeDirectory v=20500 size=771 flags=0x10000(runtime) hashes=19+2 location=embedded"),
 				test.AssertContains("Hash type=sha256 size=32"),
-				test.AssertContains("CandidateCDHash sha256=a4cd4a5f49f232086ba698ec3bba3f086f432dea"),
-				test.AssertContains("CandidateCDHashFull sha256=a4cd4a5f49f232086ba698ec3bba3f086f432deae7d6ba648895e935b5098307"),
-				test.AssertContains("CDHash=a4cd4a5f49f232086ba698ec3bba3f086f432dea"),
-				test.AssertContains("CMSDigest=a4cd4a5f49f232086ba698ec3bba3f086f432deae7d6ba648895e935b5098307"),
+				test.AssertContains("CandidateCDHash sha256=6d103445e8b004b078ec736b029868522e40d22d"),
+				test.AssertContains("CandidateCDHashFull sha256=6d103445e8b004b078ec736b029868522e40d22daf33a010dde0c0cb61a2fdae"),
+				test.AssertContains("CDHash=6d103445e8b004b078ec736b029868522e40d22d"),
+				test.AssertContains("CMSDigest=6d103445e8b004b078ec736b029868522e40d22daf33a010dde0c0cb61a2fdae"),
 				test.AssertContains("CMSDigestType=2"),
 				test.AssertContains("Signature size="), // assert not adhoc
 				test.AssertContains("Authority=quill-test-leaf"),

--- a/quill/sign_test.go
+++ b/quill/sign_test.go
@@ -190,12 +190,12 @@ func TestSign(t *testing.T) {
 				failWithoutFullChain: true,
 			},
 			assertions: []test.OutputAssertion{
-				test.AssertContains("CodeDirectory v=20500 size=771 flags=0x10000(runtime) hashes=19+2 location=embedded"),
+				test.AssertContains("CodeDirectory v=20500 size=643 flags=0x10000(runtime) hashes=15+2 location=embedded"),
 				test.AssertContains("Hash type=sha256 size=32"),
-				test.AssertContains("CandidateCDHash sha256=6d103445e8b004b078ec736b029868522e40d22d"),
-				test.AssertContains("CandidateCDHashFull sha256=6d103445e8b004b078ec736b029868522e40d22daf33a010dde0c0cb61a2fdae"),
-				test.AssertContains("CDHash=6d103445e8b004b078ec736b029868522e40d22d"),
-				test.AssertContains("CMSDigest=6d103445e8b004b078ec736b029868522e40d22daf33a010dde0c0cb61a2fdae"),
+				test.AssertContains("CandidateCDHash sha256=13d846da55c5a1eaddbe8a7a5ca2774b46026b7f"),
+				test.AssertContains("CandidateCDHashFull sha256=13d846da55c5a1eaddbe8a7a5ca2774b46026b7f979029faac974668f0d97c6a"),
+				test.AssertContains("CDHash=13d846da55c5a1eaddbe8a7a5ca2774b46026b7f"),
+				test.AssertContains("CMSDigest=13d846da55c5a1eaddbe8a7a5ca2774b46026b7f979029faac974668f0d97c6a"),
 				test.AssertContains("CMSDigestType=2"),
 				test.AssertContains("Signature size="), // assert not adhoc
 				test.AssertContains("Authority=quill-test-leaf"),


### PR DESCRIPTION
A few test fixture certs have an expiration period. For one of the fixtures I upped the period so we don't need to do this as frequently. There were a couple of extra/unnecessary flags present that the latest openssl now fails on, so they were removed.

Additionally it was necessary to update the version of go used as well as the linter version (these go hand in hand). In doing so I used the main linter config we have in syft here as well.