### PR TITLE
Add kernel critical extension bypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ CHANGELOG.md
 .tmp/
 coverage.txt
 bin/
+cmd/quill/quill
 
 # Binaries for programs and plugins
 *.exe

--- a/quill/pki/certchain/verify.go
+++ b/quill/pki/certchain/verify.go
@@ -54,11 +54,13 @@ func VerifyForCodeSigning(certs []*x509.Certificate, failWithoutFullChain bool) 
 		},
 	}
 
-	// ignore "devid_execute" critical extension
+	// ignore "devid_execute" and "devid_kernel" critical extensions
 	temp := leaf.UnhandledCriticalExtensions[:0]
 	for _, ex := range leaf.UnhandledCriticalExtensions {
 		switch ex.String() {
-		case "1.2.840.113635.100.6.1.13":
+		case "1.2.840.113635.100.6.1.13": // devid_execute
+			continue
+		case "1.2.840.113635.100.6.1.18": // devid_kernel
 			continue
 		default:
 			temp = append(temp, ex)


### PR DESCRIPTION
The certificate files I got from Apple for my project also contain another critical extension: "devid_kernel".
I added a bypass for it, same way as there was previously there a bypass for "devid_execute".
