### PR TITLE
Store frame values not references

### DIFF
--- a/cmd/quill/internal/ui/ui.go
+++ b/cmd/quill/internal/ui/ui.go
@@ -41,7 +41,7 @@ func New(_, quiet bool) *UI {
 	h := handler.New()
 	return &UI{
 		handler: h,
-		frame:   frame.New(),
+		frame:   *frame.New(),
 		running: &sync.WaitGroup{},
 		quiet:   quiet,
 	}
@@ -50,7 +50,7 @@ func New(_, quiet bool) *UI {
 func (m *UI) Setup(subscription partybus.Unsubscribable) error {
 	// we still want to collect log messages, however, we also the logger shouldn't write to the screen directly
 	if logWrapper, ok := log.Get().(logger.Controller); ok {
-		logWrapper.SetOutput(m.frame.(*frame.Frame).Footer())
+		logWrapper.SetOutput(m.frame.(frame.Frame).Footer())
 	}
 
 	m.subscription = subscription
@@ -170,7 +170,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				continue
 			}
 			cmds = append(cmds, newModel.Init())
-			m.frame.(*frame.Frame).AppendModel(newModel)
+			f := m.frame.(frame.Frame)
+			f.AppendModel(newModel)
+			m.frame = f
 		}
 		// intentionally fallthrough to update the frame model
 	}


### PR DESCRIPTION
Before this fix the first UI update iteration would store a reference to a `frame.Frame` and subsequent iterations would store copies -- so type assertions after the first iteration would fail. When working with bubbletea the models passed during execution should always be copies and not references to ensure that an instances state is updated within the proper point in the UI lifecycle (during `Update()`) and nowhere else.

Fixes #529