### PR TITLE
chore(deps): restore Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/quill
 
-go 1.26.2
+go 1.25.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.0 (pre-#728). Bumped in #728 (merge bbbaeef581a1f34dd16e59e93e57688393fdf153).