### PR TITLE
Support signing with hsm

### DIFF
--- a/.github/workflows/apple-e2e-kms.yaml
+++ b/.github/workflows/apple-e2e-kms.yaml
@@ -1,0 +1,115 @@
+name: "Apple E2E (KMS)"
+
+# Manual end-to-end validation of the AWS KMS-backed signing path against the
+# real Apple Notary service. Builds a quill snapshot, signs the resulting binary
+# with a real KMS-resident Developer ID key, runs codesign --verify, and submits
+# the binary to Apple for notarization. This is the only test that proves the
+# CMS we produce around a KMS-resident key is acceptable to Apple.
+#
+# Triggered manually because Apple Notary has rate limits and outages we don't
+# want gating PR turnaround. Per-PR coverage is provided by
+# quill/sign_kms_test.go:TestSign_KMS which proves byte-identical output to the
+# validated P12 path.
+#
+# One-time setup (see docs/hsm-signing.md):
+#   - AWS KMS asymmetric key (RSA_2048 SIGN_VERIFY)
+#   - IAM role with kms:Sign + kms:GetPublicKey, OIDC trust on this repo
+#   - Developer ID certificate enrolled against the KMS key, chain.pem assembled
+#   - Repo Variables: QUILL_KMS_KEY_URI, QUILL_KMS_CERT_CHAIN_PEM,
+#     AWS_KMS_SIGNING_ROLE_ARN, AWS_KMS_REGION
+#   - Secrets (already present): APPLE_NOTARY_ISSUER, APPLE_NOTARY_KEY_ID,
+#     APPLE_NOTARY_KEY
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sign-and-notarize:
+    name: "Sign and notarize quill via KMS"
+    runs-on: macos-15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b630002463f9f499d5ff8c # v5.1.0
+        with:
+          role-to-assume: ${{ vars.AWS_KMS_SIGNING_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_KMS_REGION }}
+
+      - name: Materialize cert chain
+        env:
+          CERT_CHAIN: ${{ vars.QUILL_KMS_CERT_CHAIN_PEM }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$CERT_CHAIN" > "${RUNNER_TEMP}/chain.pem"
+
+      - name: Build quill snapshot
+        run: make snapshot
+
+      - name: Locate snapshot binary
+        run: |
+          set -euo pipefail
+          QUILL_BIN="$(find ./snapshot -type f -name quill -path '*darwin*' | head -1)"
+          if [ -z "$QUILL_BIN" ]; then
+            echo "could not locate snapshot quill binary under ./snapshot" >&2
+            find ./snapshot -type f >&2 || true
+            exit 1
+          fi
+          echo "QUILL_BIN=$QUILL_BIN" >> "$GITHUB_ENV"
+
+      - name: Smoke test quill csr
+        env:
+          KMS_KEY_URI: ${{ vars.QUILL_KMS_KEY_URI }}
+        run: |
+          set -euo pipefail
+          "$QUILL_BIN" csr \
+            --kms-key "$KMS_KEY_URI" \
+            --common-name "quill-ci-csr-smoke" \
+            --out "${RUNNER_TEMP}/smoke.csr" \
+            -vv
+          openssl req -in "${RUNNER_TEMP}/smoke.csr" -verify -noout -text
+
+      - name: Sign quill with KMS
+        env:
+          KMS_KEY_URI: ${{ vars.QUILL_KMS_KEY_URI }}
+        run: |
+          set -euo pipefail
+          cp "$QUILL_BIN" "${RUNNER_TEMP}/quill-signed"
+          "$QUILL_BIN" sign "${RUNNER_TEMP}/quill-signed" \
+            --kms-key "$KMS_KEY_URI" \
+            --kms-cert-chain "${RUNNER_TEMP}/chain.pem" \
+            -vv
+
+      - name: Verify signature with codesign
+        run: |
+          set -euo pipefail
+          codesign -dv --verbose=4 "${RUNNER_TEMP}/quill-signed"
+          codesign --verify --strict --deep "${RUNNER_TEMP}/quill-signed"
+
+      - name: Notarize with Apple
+        env:
+          QUILL_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+        run: |
+          set -euo pipefail
+          "$QUILL_BIN" notarize "${RUNNER_TEMP}/quill-signed" --wait -vv
+
+      - name: Upload signed binary
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: quill-signed
+          path: ${{ runner.temp }}/quill-signed
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -121,11 +121,41 @@ $ quill p12 attach-chain [path-to-p12-from-apple]
 At this point you can use `quill p12 describe` to confirm the full certificate chain is attached.
 
 
+### HSM-backed signing (AWS KMS)
+
+If you'd rather not have a private key on disk at all, quill can sign with a key that lives in AWS KMS — quill calls
+`kms:Sign` and gets back a signature, the private key never leaves the HSM. The certificate chain remains required (it's
+public material), but the dangerous half — the private key — is never exposed to the build machine.
+
+```bash
+$ quill sign [path/to/binary] \
+    --kms-key awskms:///alias/my-quill-signing-key \
+    --kms-cert-chain ./chain.pem
+```
+
+`--kms-key` accepts the [sigstore-style URI scheme](https://docs.sigstore.dev/cosign/key_management/overview/) so the
+same URI form works elsewhere. `--kms-cert-chain` is a PEM file containing the leaf cert plus any intermediates that
+pair with the KMS key — file path, base64 contents, or `env:VAR_NAME` are all accepted (mirrors the `--p12` ergonomics).
+
+To enroll the key with Apple, generate a CSR signed by the KMS:
+
+```bash
+$ quill csr --kms-key awskms:///alias/my-quill-signing-key \
+    --common-name "Developer ID Application: My Org (TEAMID)" \
+    --organization "My Org" --organizational-unit TEAMID --country US \
+    --out csr.pem
+```
+
+Submit `csr.pem` to Apple Developer, download the resulting cert, and assemble it with the Apple intermediate(s) into
+`chain.pem`. See [`docs/hsm-signing.md`](docs/hsm-signing.md) for the full walkthrough including IAM policy,
+threat model, and CI setup.
+
 ## Commands
 
 - `sign [binary-file]`: sign a mac executable binary
 - `notarize [binary-file]`: notarize a signed a mac binary with Apple's Notary service
 - `sign-and-notarize [binary-file]` sign and notarize a mac binary
+- `csr`: generate a CSR signed by a KMS-resident key (for enrolling a Developer ID cert against an HSM keypair)
 - `submission list`: list previous submissions to Apple's Notary service
 - `submission logs [id]`: fetch logs for an existing submission from Apple's Notary service
 - `submission status [id]`: check against Apple's Notary service to see the status of a notarization submission request
@@ -148,6 +178,18 @@ log:
   
   # file to write all loge entries to (env var: "QUILL_LOG_FILE")
   file: ""
+
+sign:
+  # PKCS#12 input (existing): file path, base64, or env:VAR_NAME (env var: "QUILL_SIGN_P12")
+  p12: ""
+
+  # KMS-backed signing (env var: "QUILL_SIGN_KMS_KEY"). Mutually exclusive with p12.
+  kms:
+    # URI of the KMS key (e.g. awskms:///arn:aws:kms:us-east-1:111122223333:key/...)
+    key: ""
+    # PEM cert chain that pairs with the KMS key — file path, base64, or env:VAR_NAME
+    # (env var: "QUILL_SIGN_KMS_CERT_CHAIN"). Certificates are public material, safe to commit.
+    cert-chain: ""
 ```
 
 ## Why make this?

--- a/cmd/quill/cli/cli.go
+++ b/cmd/quill/cli/cli.go
@@ -66,6 +66,7 @@ func New(id clio.Identification) clio.Application {
 	root.AddCommand(commands.Test(app))
 	root.AddCommand(commands.Describe(app))
 	root.AddCommand(commands.EmbeddedCerts(app))
+	root.AddCommand(commands.CSR(app))
 	root.AddCommand(submission)
 	root.AddCommand(extract)
 	root.AddCommand(p12)

--- a/cmd/quill/cli/commands/csr.go
+++ b/cmd/quill/cli/commands/csr.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/fangs"
+	"github.com/anchore/quill/cmd/quill/cli/options"
+	"github.com/anchore/quill/internal/bus"
+	"github.com/anchore/quill/quill/pki/kms"
+
+	// register KMS providers so kms.Open recognizes their URI schemes.
+	_ "github.com/anchore/quill/quill/pki/kms/aws"
+)
+
+var _ fangs.FlagAdder = &csrConfig{}
+
+type csrConfig struct {
+	options.CSR `yaml:",inline" json:",inline" mapstructure:",squash"`
+}
+
+func CSR(app clio.Application) *cobra.Command {
+	opts := &csrConfig{}
+
+	return app.SetupCommand(&cobra.Command{
+		Use:   "csr",
+		Short: "generate a Certificate Signing Request signed by a KMS-resident key",
+		Long: `Generate a CSR whose public key is fetched from a KMS and whose signature is produced by the KMS.
+
+The resulting CSR is what you submit to Apple Developer (or another CA) to enroll a certificate paired with an HSM-resident keypair. Apple's normal CSR workflow assumes the private key lives locally — this command provides the equivalent for keys that never leave a KMS.
+
+Example:
+  quill csr --kms-key awskms:///alias/quill-signing \
+            --common-name "Developer ID Application: My Org (TEAMID)" \
+            --organization "My Org" --organizational-unit TEAMID --country US \
+            --out csr.pem`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			defer bus.Exit()
+			return runCSR(opts.CSR)
+		},
+	}, opts)
+}
+
+func runCSR(opts options.CSR) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	signer, err := kms.Open(context.Background(), opts.KMSKey)
+	if err != nil {
+		return fmt.Errorf("opening KMS signer: %w", err)
+	}
+	defer signer.Close()
+
+	tmpl := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: opts.CommonName,
+		},
+		// pin to PKCS#1 v1.5 to match the runtime signing path; KMS provider
+		// rejects PSS at the seam regardless, but this keeps x509's algorithm
+		// hint consistent.
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	if opts.Organization != "" {
+		tmpl.Subject.Organization = []string{opts.Organization}
+	}
+	if opts.OrganizationalUnit != "" {
+		tmpl.Subject.OrganizationalUnit = []string{opts.OrganizationalUnit}
+	}
+	if opts.Country != "" {
+		tmpl.Subject.Country = []string{opts.Country}
+	}
+	if opts.EmailAddress != "" {
+		tmpl.EmailAddresses = []string{opts.EmailAddress}
+	}
+
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, signer)
+	if err != nil {
+		return fmt.Errorf("creating CSR: %w", err)
+	}
+
+	out := os.Stdout
+	if opts.Out != "" {
+		f, err := os.Create(opts.Out)
+		if err != nil {
+			return fmt.Errorf("opening output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if err := pem.Encode(out, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}); err != nil {
+		return fmt.Errorf("writing CSR PEM: %w", err)
+	}
+	return nil
+}

--- a/cmd/quill/cli/commands/csr_test.go
+++ b/cmd/quill/cli/commands/csr_test.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/quill/cmd/quill/cli/options"
+	"github.com/anchore/quill/quill/pki/kms"
+)
+
+func TestRunCSR(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	registerFakeKMS(t, "fakekms-csr", key)
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "csr.pem")
+
+	err = runCSR(options.CSR{
+		KMSKey:             "fakekms-csr:///some-key",
+		CommonName:         "Developer ID Application: Test (TEAMID)",
+		Organization:       "Test Org",
+		OrganizationalUnit: "TEAMID",
+		Country:            "US",
+		Out:                out,
+	})
+	require.NoError(t, err)
+
+	pemBytes, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(pemBytes)
+	require.NotNil(t, block)
+	require.Equal(t, "CERTIFICATE REQUEST", block.Type)
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	require.NoError(t, err)
+
+	// signature is real and verifies against the public key from KMS
+	require.NoError(t, csr.CheckSignature())
+
+	// subject fields round-trip
+	require.Equal(t, "Developer ID Application: Test (TEAMID)", csr.Subject.CommonName)
+	require.Equal(t, []string{"Test Org"}, csr.Subject.Organization)
+	require.Equal(t, []string{"TEAMID"}, csr.Subject.OrganizationalUnit)
+	require.Equal(t, []string{"US"}, csr.Subject.Country)
+
+	// CSR must use PKCS#1 v1.5, NOT PSS (matches signing path policy)
+	require.Equal(t, x509.SHA256WithRSA, csr.SignatureAlgorithm)
+}
+
+func TestRunCSR_ValidationFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		opts options.CSR
+	}{
+		{
+			name: "missing kms key",
+			opts: options.CSR{CommonName: "x"},
+		},
+		{
+			name: "missing common name",
+			opts: options.CSR{KMSKey: "fakekms-csr:///x"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runCSR(tt.opts)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRunCSR_UnknownScheme(t *testing.T) {
+	err := runCSR(options.CSR{
+		KMSKey:     "definitely-not-a-scheme:///k",
+		CommonName: "x",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no kms provider")
+}
+
+// --- fake provider (mirrors the one in pki/signing_material_kms_test.go but
+// scoped to this package since cmd/quill/cli/commands cannot import test
+// helpers from internal pki) ---
+
+func registerFakeKMS(t *testing.T, scheme string, key *rsa.PrivateKey) {
+	t.Helper()
+	kms.Register(&fakeKMSProvider{scheme: scheme, key: key})
+}
+
+type fakeKMSProvider struct {
+	scheme string
+	key    *rsa.PrivateKey
+}
+
+func (p *fakeKMSProvider) Scheme() string { return p.scheme }
+
+func (p *fakeKMSProvider) Open(_ context.Context, uri string) (kms.Signer, error) {
+	keyID := strings.TrimPrefix(uri, p.scheme+":///")
+	return &fakeKMSSigner{key: p.key, keyID: keyID}, nil
+}
+
+type fakeKMSSigner struct {
+	key   *rsa.PrivateKey
+	keyID string
+}
+
+func (s *fakeKMSSigner) Public() crypto.PublicKey { return &s.key.PublicKey }
+func (s *fakeKMSSigner) KeyID() string             { return s.keyID }
+func (s *fakeKMSSigner) Close() error              { return nil }
+
+func (s *fakeKMSSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return rsa.SignPKCS1v15(rand.Reader, s.key, opts.HashFunc(), digest)
+}

--- a/cmd/quill/cli/commands/sign.go
+++ b/cmd/quill/cli/commands/sign.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -46,28 +47,41 @@ func Sign(app clio.Application) *cobra.Command {
 }
 
 func sign(binPath string, opts options.Signing) error {
+	if opts.KMS.Key != "" && opts.P12 != "" {
+		return fmt.Errorf("--kms-key and --p12 are mutually exclusive")
+	}
+
 	cfg := quill.SigningConfig{
 		Path: binPath,
 	}
 
-	if opts.P12 != "" {
-		if opts.AdHoc {
-			log.Warn("ad-hoc signing is enabled, but a p12 file was also provided. The p12 file will be ignored.")
-		} else {
-			p12Content, err := loadP12Interactively(opts.P12, opts.Password)
-			if err != nil {
-				return fmt.Errorf("unable to decode p12 file: %w", err)
-			}
-			if p12Content == nil {
-				return fmt.Errorf("no content found in the p12 file")
-			}
-
-			replacement, err := quill.NewSigningConfigFromP12(binPath, *p12Content, opts.FailWithoutFullChain)
-			if err != nil {
-				return fmt.Errorf("unable to read p12: %w", err)
-			}
-			cfg = *replacement
+	switch {
+	case opts.AdHoc:
+		if opts.KMS.Key != "" || opts.P12 != "" {
+			log.Warn("ad-hoc signing is enabled; --kms-key / --p12 will be ignored")
 		}
+
+	case opts.KMS.Key != "":
+		replacement, err := quill.NewSigningConfigFromKMS(context.Background(), binPath, opts.KMS.Key, opts.KMS.CertChain, opts.FailWithoutFullChain)
+		if err != nil {
+			return fmt.Errorf("unable to set up KMS-backed signer: %w", err)
+		}
+		cfg = *replacement
+
+	case opts.P12 != "":
+		p12Content, err := loadP12Interactively(opts.P12, opts.Password)
+		if err != nil {
+			return fmt.Errorf("unable to decode p12 file: %w", err)
+		}
+		if p12Content == nil {
+			return fmt.Errorf("no content found in the p12 file")
+		}
+
+		replacement, err := quill.NewSigningConfigFromP12(binPath, *p12Content, opts.FailWithoutFullChain)
+		if err != nil {
+			return fmt.Errorf("unable to read p12: %w", err)
+		}
+		cfg = *replacement
 	}
 
 	cfg.WithIdentity(opts.Identity)

--- a/cmd/quill/cli/commands/sign_test.go
+++ b/cmd/quill/cli/commands/sign_test.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/quill/cmd/quill/cli/options"
+)
+
+func TestSign_KMSAndP12MutuallyExclusive(t *testing.T) {
+	err := sign("/tmp/some-binary", options.Signing{
+		KMS: options.KMS{Key: "awskms:///alias/whatever"},
+		P12: "/some/path.p12",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/cmd/quill/cli/options/csr.go
+++ b/cmd/quill/cli/options/csr.go
@@ -1,0 +1,83 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/anchore/fangs"
+)
+
+var _ interface {
+	fangs.FlagAdder
+	fangs.FieldDescriber
+} = (*CSR)(nil)
+
+// CSR collects the inputs needed to generate a Certificate Signing Request
+// against a KMS-resident key. The output CSR is what users submit to Apple
+// Developer to enroll a Developer ID certificate paired with the HSM key.
+type CSR struct {
+	KMSKey             string `yaml:"kms-key" json:"kms-key" mapstructure:"kms-key"`
+	CommonName         string `yaml:"common-name" json:"common-name" mapstructure:"common-name"`
+	Organization       string `yaml:"organization" json:"organization" mapstructure:"organization"`
+	OrganizationalUnit string `yaml:"organizational-unit" json:"organizational-unit" mapstructure:"organizational-unit"`
+	Country            string `yaml:"country" json:"country" mapstructure:"country"`
+	EmailAddress       string `yaml:"email" json:"email" mapstructure:"email"`
+	Out                string `yaml:"out" json:"out" mapstructure:"out"`
+}
+
+func (o *CSR) Validate() error {
+	if o.KMSKey == "" {
+		return fmt.Errorf("--kms-key is required")
+	}
+	if o.CommonName == "" {
+		return fmt.Errorf("--common-name is required")
+	}
+	return nil
+}
+
+func (o *CSR) AddFlags(flags fangs.FlagSet) {
+	flags.StringVarP(
+		&o.KMSKey,
+		"kms-key", "",
+		"URI of the KMS key to build the CSR around (e.g. awskms:///alias/quill-signing).\nThe public key is fetched from KMS and the request is signed by KMS.",
+	)
+	flags.StringVarP(
+		&o.CommonName,
+		"common-name", "",
+		"CSR Common Name (CN), e.g. \"Developer ID Application: My Org (TEAMID)\"",
+	)
+	flags.StringVarP(
+		&o.Organization,
+		"organization", "",
+		"CSR Organization (O)",
+	)
+	flags.StringVarP(
+		&o.OrganizationalUnit,
+		"organizational-unit", "",
+		"CSR Organizational Unit (OU). For Apple Developer ID this is typically the 10-character team ID.",
+	)
+	flags.StringVarP(
+		&o.Country,
+		"country", "",
+		"CSR Country (C), 2-letter ISO 3166-1 alpha-2 code (e.g. US)",
+	)
+	flags.StringVarP(
+		&o.EmailAddress,
+		"email", "",
+		"CSR email address",
+	)
+	flags.StringVarP(
+		&o.Out,
+		"out", "o",
+		"path to write the CSR PEM (defaults to stdout)",
+	)
+}
+
+func (o *CSR) DescribeFields(d fangs.FieldDescriptionSet) {
+	d.Add(&o.KMSKey, "URI of the KMS key the CSR is built against")
+	d.Add(&o.CommonName, "Common Name (CN) for the CSR subject")
+	d.Add(&o.Organization, "Organization (O) for the CSR subject")
+	d.Add(&o.OrganizationalUnit, "Organizational Unit (OU) for the CSR subject")
+	d.Add(&o.Country, "Country (C) for the CSR subject")
+	d.Add(&o.EmailAddress, "email address for the CSR subject")
+	d.Add(&o.Out, "path to write the CSR PEM (defaults to stdout)")
+}

--- a/cmd/quill/cli/options/kms.go
+++ b/cmd/quill/cli/options/kms.go
@@ -1,0 +1,47 @@
+package options
+
+import (
+	"github.com/anchore/fangs"
+)
+
+var _ interface {
+	fangs.FlagAdder
+	fangs.PostLoader
+	fangs.FieldDescriber
+} = (*KMS)(nil)
+
+// KMS holds configuration for HSM-backed signing where the private key lives
+// in a cloud KMS (AWS KMS today; GCP KMS / Azure Key Vault are future
+// providers). Cert chain is public material — accepts file path, base64
+// contents, or "env:VAR_NAME" mirroring the --p12 ergonomics.
+type KMS struct {
+	Key       string `yaml:"key" json:"key" mapstructure:"key"`
+	CertChain string `yaml:"cert-chain" json:"cert-chain" mapstructure:"cert-chain"`
+}
+
+func (o *KMS) PostLoad() error {
+	// the cert chain is non-sensitive (public material), but redactNonFileOrEnvHint
+	// guards against accidentally logging an inline base64 blob if the user
+	// passed one as a "value" rather than a file path.
+	redactNonFileOrEnvHint(o.CertChain)
+	return nil
+}
+
+func (o *KMS) AddFlags(flags fangs.FlagSet) {
+	flags.StringVarP(
+		&o.Key,
+		"kms-key", "",
+		"URI of the KMS key to sign with (e.g. awskms:///arn:aws:kms:us-east-1:111122223333:key/...).\nThe private key never leaves the KMS — quill calls Sign and receives signature bytes back.\nMutually exclusive with --p12.",
+	)
+
+	flags.StringVarP(
+		&o.CertChain,
+		"kms-cert-chain", "",
+		"path to a PEM file containing the leaf certificate plus any intermediates that pair with the KMS key.\nThis can also be the base64-encoded PEM contents, or 'env:ENV_VAR_NAME' to read it from an environment variable.\nCertificates are public material — safe to commit, bake into images, or fetch from any non-secret store.",
+	)
+}
+
+func (o *KMS) DescribeFields(d fangs.FieldDescriptionSet) {
+	d.Add(&o.Key, "URI of the KMS key (e.g. awskms:///arn:aws:kms:...)")
+	d.Add(&o.CertChain, "path/base64/env-hint for the certificate chain that pairs with the KMS key")
+}

--- a/cmd/quill/cli/options/signing.go
+++ b/cmd/quill/cli/options/signing.go
@@ -18,6 +18,7 @@ type Signing struct {
 	TimestampServer      string `yaml:"timestamp-server" json:"timestamp-server" mapstructure:"timestamp-server"`
 	AdHoc                bool   `yaml:"ad-hoc" json:"ad-hoc" mapstructure:"ad-hoc"`
 	FailWithoutFullChain bool   `yaml:"fail-without-full-chain" json:"fail-without-full-chain" mapstructure:"fail-without-full-chain"`
+	KMS                  KMS    `yaml:"kms" json:"kms" mapstructure:"kms"`
 
 	// unbound options
 	Password     string `yaml:"password" json:"password" mapstructure:"password"` //nolint:gosec // G117 false positive: not a hardcoded secret

--- a/docs/hsm-signing.md
+++ b/docs/hsm-signing.md
@@ -1,0 +1,335 @@
+# HSM-backed code signing with quill
+
+This guide walks through signing macOS binaries with a private key that lives in AWS KMS — the key never exists on the
+build machine, in CI logs, in container images, or in artifact storage. quill calls `kms:Sign` with a digest and
+receives the signature bytes back; the rest of the signing flow (CodeDirectory hashing, CMS assembly, Mach-O patching)
+runs locally as before.
+
+## Threat model
+
+### What HSM-backed signing protects
+
+The **private key**. With AWS KMS the key is generated inside an AWS HSM and there is no API to extract it. Compromising
+the build machine, your CI runner, container images, or any artifact you ship cannot expose the private key.
+
+### What is — and isn't — sensitive
+
+| Asset | Sensitive? | Why |
+|---|---|---|
+| KMS private key | **yes (highest)** | Lives only in AWS HSMs; never leaves. Compromise = full impersonation. |
+| IAM principal with `kms:Sign` on the key | **yes** | The "private key equivalent" of this model. Lock down via IRSA / GitHub OIDC / instance profile, never long-lived access keys. Audit via CloudTrail. |
+| `chain.pem` (leaf + intermediates) | **no** | Public material by definition — certificates contain only public keys plus the CA's signature. **Already embedded in every binary you ship**; any user can extract it with `codesign -d --extract-certificates /path/to/your.app`. Safe to commit to git, bake into Docker images, or fetch from any non-secret store. |
+| CSR PEM | **no** | Same as the cert: public key + subject + a self-signature. |
+
+### Threat scenarios
+
+- *Build machine compromise (read access to `chain.pem` and source).* Attacker can verify your existing signatures —
+  which any end user can already do. They cannot sign anything new without IAM credentials authorized for `kms:Sign`
+  on the key.
+- *Stolen `chain.pem`.* Inert without the corresponding IAM principal.
+- *Stolen IAM credentials with `kms:Sign`.* Attacker can sign as you for as long as the credentials are valid. Mitigate
+  with short-lived credentials (OIDC/IRSA), IAM condition keys (`aws:SourceArn`, `aws:SourceIdentity`, MFA), and
+  CloudTrail alerting on unexpected `Sign` calls.
+- *Compared with the P12 model.* In the existing flow, both the cert and the private key live on disk in the same
+  file. Build-machine compromise = full impersonation. The KMS model removes that.
+
+### Recommended hardening
+
+- Scope `kms:Sign` to a single IAM role assumed only by your release workflow (e.g. a GitHub Actions OIDC trust policy
+  bound to a specific repo + ref).
+- Add `aws:RequestedRegion` and `aws:SourceArn` conditions to the KMS key policy.
+- Enable CloudTrail data events on the key and alert on `Sign` calls outside expected windows or principals.
+- Use a dedicated KMS key per environment (release vs. nightly vs. dev) so the blast radius of a stolen credential is
+  bounded.
+
+## End-to-end walkthrough
+
+### 1. Create an asymmetric signing key in AWS KMS
+
+In the AWS console (KMS → Customer managed keys → Create key) or via CLI:
+
+```bash
+aws kms create-key \
+  --key-spec RSA_2048 \
+  --key-usage SIGN_VERIFY \
+  --description "quill code signing"
+aws kms create-alias \
+  --alias-name alias/quill-signing \
+  --target-key-id <KEY_ID_FROM_PREVIOUS_STEP>
+```
+
+`RSA_2048`, `RSA_3072`, or `RSA_4096` all work. ECDSA keys are accepted by quill but not yet usable for Apple
+Developer ID signing (Apple still issues RSA certificates).
+
+### 2. Generate a CSR signed by the KMS key
+
+Apple's normal CSR flow assumes the private key is local. Since the key lives in KMS, use quill to generate the CSR —
+quill fetches the public key from KMS via `GetPublicKey` and signs the CSR itself via `kms:Sign`.
+
+```bash
+quill csr \
+  --kms-key awskms:///alias/quill-signing \
+  --common-name "Developer ID Application: My Org (TEAMID)" \
+  --organization "My Org" \
+  --organizational-unit TEAMID \
+  --country US \
+  --out csr.pem
+```
+
+Verify the CSR is well-formed:
+
+```bash
+openssl req -in csr.pem -verify -noout -text
+```
+
+### 3. Enroll with Apple
+
+Sign in to [Apple Developer → Certificates](https://developer.apple.com/account/resources/certificates/list) and create
+a new "Developer ID Application" certificate, uploading `csr.pem` when prompted. Download the resulting `.cer` file.
+
+### 4. Assemble the certificate chain
+
+Concatenate the leaf you got from Apple with the Apple intermediate and root certificates (download from
+[Apple's CA page](https://www.apple.com/certificateauthority/)) into a single PEM file:
+
+```bash
+# convert Apple's DER cert to PEM
+openssl x509 -inform DER -in developerid.cer -out leaf.pem
+
+# concatenate leaf + intermediates (+ root, optional)
+cat leaf.pem DeveloperIDCA.pem AppleIncRootCertificate.pem > chain.pem
+```
+
+quill also embeds Apple's intermediate and root certificates internally — if your `chain.pem` only contains the leaf,
+quill will attempt to fill in the rest from its embedded store. (You can still pass `--fail-without-full-chain` to
+require the file itself be complete.)
+
+`chain.pem` is non-sensitive; commit it, bake it into your Docker image, or store it in S3 — whatever fits your build.
+
+### 5. Sign
+
+```bash
+quill sign /path/to/my-binary \
+  --kms-key awskms:///alias/quill-signing \
+  --kms-cert-chain ./chain.pem
+```
+
+Verify the signature:
+
+```bash
+codesign -dv --verbose=4 /path/to/my-binary
+codesign --verify --verbose=4 /path/to/my-binary
+```
+
+Notarize as you would normally:
+
+```bash
+quill notarize /path/to/my-binary
+```
+
+…or do both in one step:
+
+```bash
+quill sign-and-notarize /path/to/my-binary \
+  --kms-key awskms:///alias/quill-signing \
+  --kms-cert-chain ./chain.pem
+```
+
+## IAM policy
+
+Attach to the IAM principal (role / user) that runs `quill sign` or `quill csr`. Replace the resource ARN with your
+key's ARN.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "QuillSigning",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Sign",
+        "kms:GetPublicKey"
+      ],
+      "Resource": "arn:aws:kms:us-east-1:111122223333:key/abcd-..."
+    }
+  ]
+}
+```
+
+`kms:DescribeKey` is **not** required — quill picks the signing algorithm from the public key type, not from KMS's
+declared algorithm list (this is intentional; it pins us to PKCS#1 v1.5, which Apple Developer ID requires).
+
+## CI integration
+
+Use short-lived credentials. Long-lived AWS access keys defeat the purpose.
+
+### GitHub Actions (OIDC)
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::111122223333:role/quill-signing-release
+          aws-region: us-east-1
+      - run: |
+          quill sign ./dist/my-app \
+            --kms-key awskms:///alias/quill-signing \
+            --kms-cert-chain ./chain.pem
+```
+
+The IAM trust policy on `quill-signing-release` should constrain to a specific repo and ref:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": { "Federated": "arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com" },
+  "Action": "sts:AssumeRoleWithWebIdentity",
+  "Condition": {
+    "StringEquals": {
+      "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+      "token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/tags/v*"
+    }
+  }
+}
+```
+
+### EKS (IRSA) and EC2
+
+Use IRSA service-account-bound roles on EKS, or instance profiles on EC2. Both flows are picked up automatically by the
+default AWS credential chain — no quill-side configuration needed beyond `--kms-key`.
+
+## URI reference
+
+quill uses the same KMS URI scheme as cosign / sigstore:
+
+| URI | Notes |
+|---|---|
+| `awskms:///<key-uuid>` | Bare key ID. Region from `AWS_REGION` / `~/.aws/config`. |
+| `awskms:///alias/<name>` | Alias name. Region from `AWS_REGION`. |
+| `awskms:///arn:aws:kms:<region>:<account>:key/<uuid>` | Key ARN. Region taken from the ARN. |
+| `awskms:///arn:aws:kms:<region>:<account>:alias/<name>` | Alias ARN. Region taken from the ARN. |
+| `awskms://<endpoint>/<key-id>` | Custom endpoint (e.g. LocalStack). |
+
+GCP KMS (`gcpkms://`) and Azure Key Vault (`azurekms://`) are planned as additional providers; the URI scheme is the
+same for all of them.
+
+## Validating quill's KMS code path against Apple
+
+Two layers of validation:
+
+**Per-PR (automatic, no setup):** the `TestSign_KMS` test in `quill/sign_test.go`'s sister
+file routes the existing trusted-fixture cert chains through an in-process fake KMS provider
+holding the same RSA key. It asserts the resulting Mach-O has byte-identical CodeDirectory +
+CMS to the P12 path and passes `codesign --verify`. Run as part of normal `go test ./...` —
+catches any regression that changes the KMS code path's output.
+
+**Pre-release (manual dispatch):** the `Apple E2E (KMS)` workflow at
+`.github/workflows/apple-e2e-kms.yaml` performs the full Apple round-trip — real KMS key,
+real Developer ID cert, real `quill notarize` against Apple's Notary service. This is the
+only test that proves Apple actually accepts a CMS we built around a KMS-resident key. Run
+before tagging a release by dispatching the workflow from the Actions tab.
+
+The workflow is `workflow_dispatch` only (not `pull_request`) because Apple Notary has rate
+limits, occasional outages, and 1-5+ minute submission latency that would make per-PR runs
+flaky and slow. The unit-level `TestSign_KMS` covers per-PR regressions.
+
+### One-time setup for the Apple E2E workflow
+
+This setup must be done once, by a human, before the workflow can run:
+
+1. **Create the KMS key.**
+   ```bash
+   aws kms create-key --key-spec RSA_2048 --key-usage SIGN_VERIFY \
+     --description "quill CI signing key"
+   aws kms create-alias --alias-name alias/quill-ci-signing \
+     --target-key-id <KEY_ID>
+   ```
+
+2. **Create an IAM role for the workflow.** Use the IAM policy from the section above
+   (`kms:Sign`, `kms:GetPublicKey`). The trust policy should bind to GitHub OIDC for this
+   repo, restricted to `workflow_dispatch` events from the default branch:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": { "Federated": "arn:aws:iam::<ACCOUNT>:oidc-provider/token.actions.githubusercontent.com" },
+       "Action": "sts:AssumeRoleWithWebIdentity",
+       "Condition": {
+         "StringEquals": {
+           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+         },
+         "StringLike": {
+           "token.actions.githubusercontent.com:sub": "repo:<ORG>/<REPO>:ref:refs/heads/main"
+         }
+       }
+     }]
+   }
+   ```
+
+3. **Generate a CSR locally and submit to Apple.** Build quill with these changes, then:
+   ```bash
+   quill csr --kms-key awskms:///alias/quill-ci-signing \
+     --common-name "Developer ID Application: <Org Name> (<TEAMID>)" \
+     --organization "<Org Name>" --organizational-unit <TEAMID> --country US \
+     --out csr.pem
+   ```
+   Submit `csr.pem` at <https://developer.apple.com/account/resources/certificates/list>,
+   download the issued cert, and assemble `chain.pem` (leaf + Apple intermediate + Apple root).
+
+4. **Configure repo state.** In repo Settings → Secrets and variables → Actions:
+
+   **Variables (non-secret — these are public material):**
+   - `QUILL_KMS_KEY_URI` → e.g. `awskms:///alias/quill-ci-signing`
+   - `QUILL_KMS_CERT_CHAIN_PEM` → paste the full multi-line PEM contents of `chain.pem`
+   - `AWS_KMS_SIGNING_ROLE_ARN` → ARN of the IAM role from step 2
+   - `AWS_KMS_REGION` → e.g. `us-east-1`
+
+   **Secrets (already present from existing release flow):**
+   - `APPLE_NOTARY_ISSUER`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_KEY`
+
+5. **Dispatch the workflow** from the Actions tab to confirm everything is wired correctly.
+
+### What the workflow does (per run)
+
+1. Assumes the AWS IAM role via OIDC.
+2. Materializes `chain.pem` from the repo Variable.
+3. Builds a quill snapshot.
+4. Runs `quill csr` against the KMS key — confirms `GetPublicKey` + `Sign` still work.
+5. Signs a copy of the freshly-built quill binary using the KMS key + cert chain.
+6. Runs `codesign --verify --strict --deep` to confirm the signature parses + validates.
+7. Submits to Apple Notary via `quill notarize --wait` — fails the job if Apple rejects.
+8. Uploads the signed-and-notarized binary as a workflow artifact for manual inspection.
+
+## Troubleshooting
+
+### `KMS public key does not match any certificate in the chain`
+
+The `chain.pem` you provided was issued for a different key. This usually means the CSR was generated against one KMS
+key but the cert was downloaded for a different one. Re-run `quill csr` against the same key you'll be signing with.
+
+### `KMS Sign … AccessDeniedException`
+
+The IAM principal lacks `kms:Sign` permission on the key. Check the key policy and the principal's IAM policy. CloudTrail
+will show the rejected call with the exact principal ARN.
+
+### `failed to verify certificate chain`
+
+`chain.pem` is missing intermediates or has them in the wrong order, and quill couldn't fill in from its embedded Apple
+store either. Re-download the Apple intermediate / root from
+[Apple's CA page](https://www.apple.com/certificateauthority/) and re-concatenate.
+
+### Signature works, but Gatekeeper rejects with "modified or invalid"
+
+quill pins the KMS signing algorithm to `RSASSA_PKCS1_V1_5_SHA_256` (matching Apple Developer ID's expectations). If you
+manually bypass that — e.g. by modifying quill — and produce a PSS signature, Gatekeeper will reject the binary because
+the CMS SignerInfo OID disagrees with the actual signature scheme.

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,11 @@ require (
 	github.com/anchore/fangs v0.0.0-20251204220743-df7ac3652565
 	github.com/anchore/go-logger v0.0.0-20251106021608-a5b0513fa9a9
 	github.com/anchore/go-macholibre v0.0.0-20250826193721-3cd206ca93aa
-	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1
+	github.com/aws/aws-sdk-go-v2/service/kms v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
 	github.com/blacktop/go-macho v1.1.263
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -43,8 +44,8 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
@@ -55,7 +56,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blacktop/go-dwarf v1.0.14 // indirect
 	github.com/charmbracelet/bubbles v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
-github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.12 h1:O3csC7HUGn2895eNrLytOJQdoL2xyJy0iYXhoZ1OmP0=
@@ -35,10 +35,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 h1:zOgq3uezl5nznfoK3ODuqb
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20/go.mod h1:z/MVwUARehy6GAg/yQ1GO2IMl0k++cu1ohP9zo887wE=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1 h1:1hWFp+52Vq8Fevy/KUhbW/1MEApMz7uitCF/PQXRJpk=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1/go.mod h1:sIec8j802/rCkCKgZV678HFR0s7lhQUYXT77tIvlaa4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 h1:SwGMTMLIlvDNyhMteQ6r8IJSBPlRdXX5d4idhIGbkXA=
@@ -51,6 +51,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 h1:2HvVAIq+
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20/go.mod h1:V4X406Y666khGa8ghKmphma/7C0DAtEQYhkq9z4vpbk=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 h1:siU1A6xjUZ2N8zjTHSXFhB9L/2OY8Dqs0xXiLjF30jA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20/go.mod h1:4TLZCmVJDM3FOu5P5TJP0zOlu9zWgDWU7aUxWbr+rcw=
+github.com/aws/aws-sdk-go-v2/service/kms v1.51.1 h1:zuSf4olLKZW8cF/W9Y5wvGT+/0raY/3kVp49KsGs0QY=
+github.com/aws/aws-sdk-go-v2/service/kms v1.51.1/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2 h1:MRNiP6nqa20aEl8fQ6PJpEq11b2d40b16sm4WD7QgMU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2/go.mod h1:FrNA56srbsr3WShiaelyWYEo70x80mXnVZ17ZZfbeqg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 h1:0GFOLzEbOyZABS3PhYfBIx2rNBACYcKty+XGkTgw1ow=
@@ -61,8 +63,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 h1:jzKAXIlhZhJbnYwHbvUQZEB
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17/go.mod h1:Al9fFsXjv4KfbzQHGe6V4NZSZQXecFcvaIF4e70FoRA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8MSU6Ch5i9PgBkcU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/blacktop/go-dwarf v1.0.14 h1:OjmzfSgg/qAKckn2tWFebcgKgJ7HOqCj7bS+CiE1lrY=

--- a/quill/pki/kms/aws/aws.go
+++ b/quill/pki/kms/aws/aws.go
@@ -1,0 +1,91 @@
+package aws
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+
+	"github.com/anchore/quill/quill/pki/kms"
+)
+
+func init() {
+	kms.Register(&provider{})
+}
+
+type provider struct{}
+
+func (p *provider) Scheme() string { return Scheme }
+
+func (p *provider) Open(ctx context.Context, uri string) (kms.Signer, error) {
+	parsed, err := parseURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	cfgOpts := []func(*config.LoadOptions) error{}
+	if region := regionFromKeyID(parsed.KeyID); region != "" {
+		cfgOpts = append(cfgOpts, config.WithRegion(region))
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, cfgOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+
+	clientOpts := []func(*awskms.Options){}
+	if parsed.Endpoint != "" {
+		clientOpts = append(clientOpts, func(o *awskms.Options) {
+			o.BaseEndpoint = aws.String(resolveEndpointURL(parsed.Endpoint))
+		})
+	}
+
+	client := awskms.NewFromConfig(awsCfg, clientOpts...)
+
+	return newSigner(ctx, client, parsed.KeyID)
+}
+
+// resolveEndpointURL adds an appropriate scheme to a bare host[:port] endpoint.
+// Localhost-ish endpoints default to http (LocalStack, moto, dev fixtures);
+// everything else defaults to https. If the user already supplied a scheme,
+// it is preserved.
+func resolveEndpointURL(endpoint string) string {
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return endpoint
+	}
+	host := endpoint
+	if i := strings.Index(host, ":"); i >= 0 {
+		host = host[:i]
+	}
+	switch {
+	case host == "localhost", strings.HasPrefix(host, "127."), host == "0.0.0.0":
+		return "http://" + endpoint
+	default:
+		return "https://" + endpoint
+	}
+}
+
+// newSigner fetches and caches the public key, returning a ready-to-use signer.
+// Splitting this out makes the signer testable with a fake kmsClient.
+func newSigner(ctx context.Context, client kmsClient, keyID string) (*signer, error) {
+	pkOut, err := client.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: &keyID})
+	if err != nil {
+		return nil, fmt.Errorf("fetching KMS public key for %q: %w", keyID, err)
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(pkOut.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parsing KMS public key for %q: %w", keyID, err)
+	}
+
+	return &signer{
+		ctx:    ctx,
+		client: client,
+		keyID:  keyID,
+		pub:    pub,
+	}, nil
+}

--- a/quill/pki/kms/aws/signer.go
+++ b/quill/pki/kms/aws/signer.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"io"
+
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// kmsClient is the subset of the aws-sdk-go-v2 KMS client we use. Defined as
+// an interface so tests can swap in a fake without standing up real AWS.
+type kmsClient interface {
+	Sign(ctx context.Context, params *awskms.SignInput, optFns ...func(*awskms.Options)) (*awskms.SignOutput, error)
+	GetPublicKey(ctx context.Context, params *awskms.GetPublicKeyInput, optFns ...func(*awskms.Options)) (*awskms.GetPublicKeyOutput, error)
+}
+
+type signer struct {
+	// ctx is bound at Open time. crypto.Signer.Sign has no context parameter,
+	// so we capture one here. This is the same pattern sigstore uses.
+	ctx    context.Context
+	client kmsClient
+	keyID  string
+	pub    crypto.PublicKey
+}
+
+func (s *signer) Public() crypto.PublicKey { return s.pub }
+
+func (s *signer) KeyID() string { return s.keyID }
+
+func (s *signer) Close() error { return nil }
+
+func (s *signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	alg, err := pickAlgorithm(s.pub, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := s.client.Sign(s.ctx, &awskms.SignInput{
+		KeyId:            &s.keyID,
+		Message:          digest,
+		MessageType:      types.MessageTypeDigest,
+		SigningAlgorithm: alg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("KMS Sign for key %q: %w", s.keyID, err)
+	}
+	return out.Signature, nil
+}
+
+// pickAlgorithm maps a public key + crypto.SignerOpts to the AWS KMS signing
+// algorithm. It deliberately refuses RSA-PSS — Apple code signing expects
+// PKCS#1 v1.5 (the rsaEncryption / sha256WithRSAEncryption OIDs in the CMS
+// SignerInfo), and the smimesign library writes the OID based on key type, not
+// the actual signature scheme. Allowing PSS bytes through would produce a CMS
+// blob whose declared algorithm disagrees with the signature contents.
+func pickAlgorithm(pub crypto.PublicKey, opts crypto.SignerOpts) (types.SigningAlgorithmSpec, error) {
+	if opts == nil {
+		return "", fmt.Errorf("kms: nil signer opts")
+	}
+
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		if _, isPSS := opts.(*rsa.PSSOptions); isPSS {
+			return "", fmt.Errorf("kms: RSA-PSS is not supported for Apple code signing (use crypto.SHA256/384/512 directly)")
+		}
+		switch opts.HashFunc() {
+		case crypto.SHA256:
+			return types.SigningAlgorithmSpecRsassaPkcs1V15Sha256, nil
+		case crypto.SHA384:
+			return types.SigningAlgorithmSpecRsassaPkcs1V15Sha384, nil
+		case crypto.SHA512:
+			return types.SigningAlgorithmSpecRsassaPkcs1V15Sha512, nil
+		default:
+			return "", fmt.Errorf("kms: unsupported hash %s for RSA key", opts.HashFunc())
+		}
+
+	case *ecdsa.PublicKey:
+		switch opts.HashFunc() {
+		case crypto.SHA256:
+			return types.SigningAlgorithmSpecEcdsaSha256, nil
+		case crypto.SHA384:
+			return types.SigningAlgorithmSpecEcdsaSha384, nil
+		case crypto.SHA512:
+			return types.SigningAlgorithmSpecEcdsaSha512, nil
+		default:
+			return "", fmt.Errorf("kms: unsupported hash %s for ECDSA key", opts.HashFunc())
+		}
+
+	default:
+		return "", fmt.Errorf("kms: unsupported public key type %T", pub)
+	}
+}

--- a/quill/pki/kms/aws/signer_test.go
+++ b/quill/pki/kms/aws/signer_test.go
@@ -1,0 +1,201 @@
+package aws
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickAlgorithm(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		pub     crypto.PublicKey
+		opts    crypto.SignerOpts
+		want    types.SigningAlgorithmSpec
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "rsa sha256 -> pkcs1v15",
+			pub:  &rsaKey.PublicKey,
+			opts: crypto.SHA256,
+			want: types.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+		},
+		{
+			name: "rsa sha384 -> pkcs1v15",
+			pub:  &rsaKey.PublicKey,
+			opts: crypto.SHA384,
+			want: types.SigningAlgorithmSpecRsassaPkcs1V15Sha384,
+		},
+		{
+			name: "rsa sha512 -> pkcs1v15",
+			pub:  &rsaKey.PublicKey,
+			opts: crypto.SHA512,
+			want: types.SigningAlgorithmSpecRsassaPkcs1V15Sha512,
+		},
+		{
+			// PSS must be rejected at the seam — Apple code signing expects
+			// PKCS#1 v1.5 OIDs in the CMS, and smimesign would otherwise emit
+			// a CMS whose declared algorithm disagrees with the signature.
+			name:    "rsa pss is rejected",
+			pub:     &rsaKey.PublicKey,
+			opts:    &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA256},
+			wantErr: require.Error,
+		},
+		{
+			name:    "rsa unsupported hash",
+			pub:     &rsaKey.PublicKey,
+			opts:    crypto.SHA1,
+			wantErr: require.Error,
+		},
+		{
+			name: "ecdsa sha256",
+			pub:  &ecdsaKey.PublicKey,
+			opts: crypto.SHA256,
+			want: types.SigningAlgorithmSpecEcdsaSha256,
+		},
+		{
+			name: "ecdsa sha384",
+			pub:  &ecdsaKey.PublicKey,
+			opts: crypto.SHA384,
+			want: types.SigningAlgorithmSpecEcdsaSha384,
+		},
+		{
+			name: "ecdsa sha512",
+			pub:  &ecdsaKey.PublicKey,
+			opts: crypto.SHA512,
+			want: types.SigningAlgorithmSpecEcdsaSha512,
+		},
+		{
+			name:    "ecdsa unsupported hash",
+			pub:     &ecdsaKey.PublicKey,
+			opts:    crypto.SHA1,
+			wantErr: require.Error,
+		},
+		{
+			name:    "unknown key type",
+			pub:     "not a key",
+			opts:    crypto.SHA256,
+			wantErr: require.Error,
+		},
+		{
+			name:    "nil opts",
+			pub:     &rsaKey.PublicKey,
+			opts:    nil,
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			got, err := pickAlgorithm(tt.pub, tt.opts)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// fakeKMSClient is an in-process stand-in for the AWS KMS SDK client. It holds
+// a real RSA key and produces real PKCS#1 v1.5 signatures, allowing the full
+// signing path to be exercised end-to-end without any AWS dependency.
+type fakeKMSClient struct {
+	key       *rsa.PrivateKey
+	signCalls []awskms.SignInput
+}
+
+func newFakeKMSClient(t *testing.T) *fakeKMSClient {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return &fakeKMSClient{key: key}
+}
+
+func (f *fakeKMSClient) GetPublicKey(_ context.Context, _ *awskms.GetPublicKeyInput, _ ...func(*awskms.Options)) (*awskms.GetPublicKeyOutput, error) {
+	der, err := x509.MarshalPKIXPublicKey(&f.key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return &awskms.GetPublicKeyOutput{PublicKey: der}, nil
+}
+
+func (f *fakeKMSClient) Sign(_ context.Context, params *awskms.SignInput, _ ...func(*awskms.Options)) (*awskms.SignOutput, error) {
+	f.signCalls = append(f.signCalls, *params)
+
+	// The fake honors the requested algorithm so tests can assert quill is
+	// requesting the correct one.
+	var hash crypto.Hash
+	switch params.SigningAlgorithm {
+	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha256:
+		hash = crypto.SHA256
+	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha384:
+		hash = crypto.SHA384
+	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha512:
+		hash = crypto.SHA512
+	default:
+		return nil, errors.New("fakeKMS: unsupported algorithm " + string(params.SigningAlgorithm))
+	}
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, f.key, hash, params.Message)
+	if err != nil {
+		return nil, err
+	}
+	return &awskms.SignOutput{Signature: sig}, nil
+}
+
+func TestSigner_EndToEnd(t *testing.T) {
+	fake := newFakeKMSClient(t)
+
+	s, err := newSigner(context.Background(), fake, "test-key-id")
+	require.NoError(t, err)
+	require.Equal(t, "test-key-id", s.KeyID())
+	require.NotNil(t, s.Public())
+	require.NoError(t, s.Close())
+
+	// sign a digest and verify with the public key
+	msg := []byte("the quick brown fox")
+	digest := sha256.Sum256(msg)
+
+	sig, err := s.Sign(rand.Reader, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+
+	require.NoError(t, rsa.VerifyPKCS1v15(&fake.key.PublicKey, crypto.SHA256, digest[:], sig))
+
+	// verify quill asked for PKCS#1 v1.5, NOT PSS
+	require.Len(t, fake.signCalls, 1)
+	require.Equal(t, types.SigningAlgorithmSpecRsassaPkcs1V15Sha256, fake.signCalls[0].SigningAlgorithm)
+	require.Equal(t, types.MessageTypeDigest, fake.signCalls[0].MessageType)
+}
+
+func TestSigner_RejectsPSS(t *testing.T) {
+	fake := newFakeKMSClient(t)
+
+	s, err := newSigner(context.Background(), fake, "test-key-id")
+	require.NoError(t, err)
+
+	digest := sha256.Sum256([]byte("payload"))
+	_, err = s.Sign(rand.Reader, digest[:], &rsa.PSSOptions{Hash: crypto.SHA256})
+	require.Error(t, err)
+	require.Empty(t, fake.signCalls, "no KMS call should be made when PSS is rejected at the seam")
+}

--- a/quill/pki/kms/aws/uri.go
+++ b/quill/pki/kms/aws/uri.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Scheme is the URI scheme used by this provider. Compatible with sigstore's
+// awskms:// URIs so users can paste URIs that already work in cosign.
+const Scheme = "awskms"
+
+// parsedURI is the structured form of an awskms:// URI.
+type parsedURI struct {
+	// Endpoint, if non-empty, overrides the default AWS endpoint. Mainly used
+	// for LocalStack and tests.
+	Endpoint string
+
+	// KeyID is the AWS KMS key identifier as taken from the URI. May be:
+	//   - bare UUID (e.g. ace8de4f-0000-1111-2222-333344445555)
+	//   - key ARN (arn:aws:kms:us-east-1:111122223333:key/<uuid>)
+	//   - alias name (alias/example)
+	//   - alias ARN (arn:aws:kms:us-east-1:111122223333:alias/example)
+	KeyID string
+}
+
+// parseURI parses an awskms:// URI per the sigstore convention:
+//
+//	awskms:///<key-id>           (no endpoint)
+//	awskms://<endpoint>/<key-id> (with endpoint, e.g. for LocalStack)
+//
+// The key-id may itself contain slashes (e.g. "alias/foo") — everything after
+// the host portion is treated as the key identifier.
+func parseURI(uri string) (*parsedURI, error) {
+	const prefix = Scheme + "://"
+	if !strings.HasPrefix(uri, prefix) {
+		return nil, fmt.Errorf("not an %s URI: %q", Scheme, uri)
+	}
+
+	rest := strings.TrimPrefix(uri, prefix)
+
+	var endpoint, keyID string
+	if strings.HasPrefix(rest, "/") {
+		// awskms:///<key-id> — no endpoint, just key id
+		keyID = strings.TrimPrefix(rest, "/")
+	} else {
+		// awskms://<endpoint>/<key-id>
+		idx := strings.Index(rest, "/")
+		if idx < 0 {
+			return nil, fmt.Errorf("malformed %s URI %q: expected '/' after endpoint", Scheme, uri)
+		}
+		endpoint = rest[:idx]
+		keyID = rest[idx+1:]
+	}
+
+	if keyID == "" {
+		return nil, fmt.Errorf("malformed %s URI %q: missing key identifier", Scheme, uri)
+	}
+	return &parsedURI{Endpoint: endpoint, KeyID: keyID}, nil
+}
+
+// regionFromKeyID extracts the AWS region from an ARN. Returns "" for non-ARN
+// forms (bare UUID, alias name) — caller should fall back to the AWS env/config
+// chain in that case.
+//
+// ARN format: arn:aws:kms:<region>:<account>:key/<uuid>
+func regionFromKeyID(keyID string) string {
+	if !strings.HasPrefix(keyID, "arn:") {
+		return ""
+	}
+	parts := strings.Split(keyID, ":")
+	if len(parts) < 4 {
+		return ""
+	}
+	return parts[3]
+}

--- a/quill/pki/kms/aws/uri_test.go
+++ b/quill/pki/kms/aws/uri_test.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantEndpoint string
+		wantKeyID    string
+		wantErr      require.ErrorAssertionFunc
+	}{
+		{
+			name:      "key arn",
+			input:     "awskms:///arn:aws:kms:us-east-1:111122223333:key/ace8de4f-0000-1111-2222-333344445555",
+			wantKeyID: "arn:aws:kms:us-east-1:111122223333:key/ace8de4f-0000-1111-2222-333344445555",
+		},
+		{
+			name:      "alias name",
+			input:     "awskms:///alias/quill-signing",
+			wantKeyID: "alias/quill-signing",
+		},
+		{
+			name:      "alias arn",
+			input:     "awskms:///arn:aws:kms:us-east-1:111122223333:alias/quill-signing",
+			wantKeyID: "arn:aws:kms:us-east-1:111122223333:alias/quill-signing",
+		},
+		{
+			name:      "bare key uuid",
+			input:     "awskms:///ace8de4f-0000-1111-2222-333344445555",
+			wantKeyID: "ace8de4f-0000-1111-2222-333344445555",
+		},
+		{
+			name:         "endpoint plus alias",
+			input:        "awskms://localhost:4566/alias/quill-signing",
+			wantEndpoint: "localhost:4566",
+			wantKeyID:    "alias/quill-signing",
+		},
+		{
+			name:         "endpoint plus arn",
+			input:        "awskms://kms.example.com/arn:aws:kms:us-west-2:000000000000:key/abcd",
+			wantEndpoint: "kms.example.com",
+			wantKeyID:    "arn:aws:kms:us-west-2:000000000000:key/abcd",
+		},
+		{
+			name:    "wrong scheme",
+			input:   "gcpkms:///projects/foo/locations/global/keyRings/r/cryptoKeys/k",
+			wantErr: require.Error,
+		},
+		{
+			name:    "no scheme",
+			input:   "alias/quill-signing",
+			wantErr: require.Error,
+		},
+		{
+			name:    "empty key id with no endpoint",
+			input:   "awskms:///",
+			wantErr: require.Error,
+		},
+		{
+			name:    "endpoint with no key id",
+			input:   "awskms://localhost:4566",
+			wantErr: require.Error,
+		},
+		{
+			name:    "endpoint with empty key id",
+			input:   "awskms://localhost:4566/",
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			got, err := parseURI(tt.input)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.wantEndpoint, got.Endpoint)
+			require.Equal(t, tt.wantKeyID, got.KeyID)
+		})
+	}
+}
+
+func TestResolveEndpointURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "localhost host:port -> http",
+			endpoint: "localhost:4566",
+			want:     "http://localhost:4566",
+		},
+		{
+			name:     "127.0.0.1 -> http",
+			endpoint: "127.0.0.1:4566",
+			want:     "http://127.0.0.1:4566",
+		},
+		{
+			name:     "0.0.0.0 -> http",
+			endpoint: "0.0.0.0:4566",
+			want:     "http://0.0.0.0:4566",
+		},
+		{
+			name:     "real hostname -> https",
+			endpoint: "kms.example.com",
+			want:     "https://kms.example.com",
+		},
+		{
+			name:     "explicit http scheme is preserved",
+			endpoint: "http://localhost:4566",
+			want:     "http://localhost:4566",
+		},
+		{
+			name:     "explicit https scheme is preserved",
+			endpoint: "https://kms.example.com",
+			want:     "https://kms.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveEndpointURL(tt.endpoint))
+		})
+	}
+}
+
+func TestRegionFromKeyID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "key arn",
+			input: "arn:aws:kms:us-east-1:111122223333:key/ace8de4f-0000-1111-2222-333344445555",
+			want:  "us-east-1",
+		},
+		{
+			name:  "alias arn",
+			input: "arn:aws:kms:eu-west-2:000000000000:alias/example",
+			want:  "eu-west-2",
+		},
+		{
+			name:  "alias name has no region",
+			input: "alias/example",
+			want:  "",
+		},
+		{
+			name:  "bare uuid has no region",
+			input: "ace8de4f-0000-1111-2222-333344445555",
+			want:  "",
+		},
+		{
+			name:  "malformed arn",
+			input: "arn:aws:kms",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, regionFromKeyID(tt.input))
+		})
+	}
+}

--- a/quill/pki/kms/kms.go
+++ b/quill/pki/kms/kms.go
@@ -1,0 +1,79 @@
+// Package kms provides an abstraction over cloud KMS / HSM signing backends.
+//
+// A KMS-backed signer implements stdlib crypto.Signer so it can drop into the
+// existing CMS signing path without changes — the private key never leaves the
+// HSM and quill only ever sees the resulting signature bytes.
+package kms
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Signer is a KMS-backed signer. It satisfies crypto.Signer so it slots into
+// existing signing paths (CMS, x509.CreateCertificateRequest, etc.) unchanged.
+type Signer interface {
+	crypto.Signer
+	io.Closer
+
+	// KeyID returns a stable identifier for the underlying key (e.g. an ARN
+	// or alias) suitable for logging and diagnostics.
+	KeyID() string
+}
+
+// Provider knows how to open a Signer from a URI of its scheme.
+type Provider interface {
+	// Scheme returns the URI scheme this provider handles, e.g. "awskms".
+	Scheme() string
+
+	// Open establishes a session to the underlying KMS service and returns a
+	// ready-to-use Signer. The provider is responsible for fetching the public
+	// key so callers can verify cert/key matches without an extra round trip.
+	Open(ctx context.Context, uri string) (Signer, error)
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Provider{}
+)
+
+// Register makes a provider available under its scheme. Intended to be called
+// from a provider package's init() so consumers opt in by blank-importing.
+func Register(p Provider) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[p.Scheme()] = p
+}
+
+// Open dispatches to the registered provider for the URI's scheme.
+func Open(ctx context.Context, uri string) (Signer, error) {
+	scheme, _, ok := strings.Cut(uri, ":")
+	if !ok || scheme == "" {
+		return nil, fmt.Errorf("kms uri missing scheme: %q", uri)
+	}
+
+	registryMu.RLock()
+	p, found := registry[scheme]
+	registryMu.RUnlock()
+
+	if !found {
+		return nil, fmt.Errorf("no kms provider registered for scheme %q (did you blank-import the provider package?)", scheme)
+	}
+	return p.Open(ctx, uri)
+}
+
+// Schemes returns the list of registered scheme names. Intended for help text
+// and diagnostics.
+func Schemes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for s := range registry {
+		out = append(out, s)
+	}
+	return out
+}

--- a/quill/pki/signing_material.go
+++ b/quill/pki/signing_material.go
@@ -1,6 +1,8 @@
 package pki
 
 import (
+	"bytes"
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/asn1"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/anchore/quill/quill/pki/apple"
 	"github.com/anchore/quill/quill/pki/certchain"
+	"github.com/anchore/quill/quill/pki/kms"
 	"github.com/anchore/quill/quill/pki/load"
 )
 
@@ -91,6 +94,71 @@ func NewSigningMaterialFromP12(p12Content load.P12Contents, failWithoutFullChain
 		Signer: signer,
 		Certs:  certchain.Sort(allCerts),
 	}, nil
+}
+
+// NewSigningMaterialFromKMS builds signing material around a KMS-backed signer.
+// The private key never leaves the HSM; quill only ever calls signer.Sign and
+// receives the signature bytes back. The cert chain is loaded from disk (or
+// base64/env hint, mirroring the p12 ergonomics) since certificates are public
+// material.
+func NewSigningMaterialFromKMS(ctx context.Context, kmsURI, certChainPath string, failWithoutFullChain bool) (*SigningMaterial, error) {
+	if certChainPath == "" {
+		return nil, fmt.Errorf("a certificate chain path is required for KMS-backed signing")
+	}
+
+	signer, err := kms.Open(ctx, kmsURI)
+	if err != nil {
+		return nil, fmt.Errorf("opening KMS signer: %w", err)
+	}
+
+	certs, err := load.Certificates(certChainPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading cert chain: %w", err)
+	}
+
+	leaf, err := matchLeafToPublicKey(signer.Public(), certs)
+	if err != nil {
+		return nil, fmt.Errorf("KMS public key does not match any certificate in the chain: %w", err)
+	}
+
+	if err := certchain.VerifyForCodeSigning(certs, failWithoutFullChain); err != nil {
+		// fall back to the embedded Apple cert store to fill any missing
+		// intermediates/roots — same recovery pattern as NewSigningMaterialFromP12.
+		store := certchain.NewCollection().WithStores(apple.GetEmbeddedCertStore())
+		remaining, findErr := certchain.Find(store, leaf)
+		if findErr != nil {
+			return nil, fmt.Errorf("unable to find remaining chain certificates: %w", findErr)
+		}
+		certs = append(certs, remaining...)
+		if err := certchain.VerifyForCodeSigning(certs, failWithoutFullChain); err != nil {
+			return nil, err
+		}
+	}
+
+	return &SigningMaterial{
+		Signer: signer,
+		Certs:  certchain.Sort(certs),
+	}, nil
+}
+
+// matchLeafToPublicKey returns the certificate in certs whose public key matches
+// pub. This both verifies the user gave us the correct cert chain for the KMS
+// key and identifies the leaf for chain-completion fallback.
+func matchLeafToPublicKey(pub crypto.PublicKey, certs []*x509.Certificate) (*x509.Certificate, error) {
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling public key: %w", err)
+	}
+	for _, c := range certs {
+		certDER, err := x509.MarshalPKIXPublicKey(c.PublicKey)
+		if err != nil {
+			continue
+		}
+		if bytes.Equal(pubDER, certDER) {
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("no matching certificate found in chain (%d certs)", len(certs))
 }
 
 func (sm *SigningMaterial) HasCertWithOrg(org string) bool {

--- a/quill/pki/signing_material_kms_test.go
+++ b/quill/pki/signing_material_kms_test.go
@@ -1,0 +1,133 @@
+package pki
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/quill/quill/pki/kms"
+)
+
+// TestNewSigningMaterialFromKMS exercises the full KMS-backed signing material
+// construction with an in-process fake KMS provider, so the path runs without
+// any AWS dependency.
+func TestNewSigningMaterialFromKMS(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	registerFakeKMS(t, "fakekms-good", key)
+
+	chainPath := writeSelfSignedLeafPEM(t, key)
+
+	sm, err := NewSigningMaterialFromKMS(context.Background(), "fakekms-good:///some-key", chainPath, false)
+	require.NoError(t, err)
+	require.NotNil(t, sm)
+	require.NotNil(t, sm.Signer)
+	require.Len(t, sm.Certs, 1)
+
+	// sanity: the signer's public key actually matches the cert
+	require.True(t, sm.Certs[0].PublicKey.(*rsa.PublicKey).Equal(sm.Signer.Public()))
+}
+
+func TestNewSigningMaterialFromKMS_KeyMismatch(t *testing.T) {
+	keyA, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyB, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	registerFakeKMS(t, "fakekms-mismatch", keyA)
+
+	// chain.pem has keyB's cert, but KMS holds keyA — should fail before any signing
+	chainPath := writeSelfSignedLeafPEM(t, keyB)
+
+	_, err = NewSigningMaterialFromKMS(context.Background(), "fakekms-mismatch:///some-key", chainPath, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match")
+}
+
+func TestNewSigningMaterialFromKMS_RequiresCertChain(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	registerFakeKMS(t, "fakekms-nochain", key)
+
+	_, err = NewSigningMaterialFromKMS(context.Background(), "fakekms-nochain:///some-key", "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate chain")
+}
+
+func TestNewSigningMaterialFromKMS_UnknownScheme(t *testing.T) {
+	_, err := NewSigningMaterialFromKMS(context.Background(), "nope:///some-key", "irrelevant", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no kms provider")
+}
+
+// --- test helpers ---
+
+// registerFakeKMS installs a kms.Provider for the given scheme that returns a
+// signer wrapping the given RSA key. Schemes are unique per test to avoid
+// cross-test contamination of the global kms registry.
+func registerFakeKMS(t *testing.T, scheme string, key *rsa.PrivateKey) {
+	t.Helper()
+	kms.Register(&fakeKMSProvider{scheme: scheme, key: key})
+}
+
+type fakeKMSProvider struct {
+	scheme string
+	key    *rsa.PrivateKey
+}
+
+func (p *fakeKMSProvider) Scheme() string { return p.scheme }
+
+func (p *fakeKMSProvider) Open(_ context.Context, uri string) (kms.Signer, error) {
+	keyID := strings.TrimPrefix(uri, p.scheme+":///")
+	return &fakeKMSSigner{key: p.key, keyID: keyID}, nil
+}
+
+type fakeKMSSigner struct {
+	key   *rsa.PrivateKey
+	keyID string
+}
+
+func (s *fakeKMSSigner) Public() crypto.PublicKey { return &s.key.PublicKey }
+func (s *fakeKMSSigner) KeyID() string             { return s.keyID }
+func (s *fakeKMSSigner) Close() error              { return nil }
+
+func (s *fakeKMSSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return rsa.SignPKCS1v15(rand.Reader, s.key, opts.HashFunc(), digest)
+}
+
+// writeSelfSignedLeafPEM creates a self-signed leaf certificate carrying the
+// given key, writes it as PEM to a temp file, and returns the path.
+func writeSelfSignedLeafPEM(t *testing.T, key *rsa.PrivateKey) string {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-leaf"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chain.pem")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	require.NoError(t, f.Close())
+	return path
+}

--- a/quill/sign.go
+++ b/quill/sign.go
@@ -1,6 +1,7 @@
 package quill
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -15,6 +16,9 @@ import (
 	"github.com/anchore/quill/quill/pki"
 	"github.com/anchore/quill/quill/pki/load"
 	"github.com/anchore/quill/quill/sign"
+
+	// register KMS providers so kms.Open recognizes their URI schemes.
+	_ "github.com/anchore/quill/quill/pki/kms/aws"
 )
 
 type SigningConfig struct {
@@ -39,6 +43,19 @@ func NewSigningConfigFromPEMs(binaryPath, certificate, privateKey, password stri
 		Path:            binaryPath,
 		Identity:        path.Base(binaryPath),
 		SigningMaterial: signingMaterial,
+	}, nil
+}
+
+func NewSigningConfigFromKMS(ctx context.Context, binaryPath, kmsURI, certChainPath string, failWithoutFullChain bool) (*SigningConfig, error) {
+	signingMaterial, err := pki.NewSigningMaterialFromKMS(ctx, kmsURI, certChainPath, failWithoutFullChain)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SigningConfig{
+		Path:            binaryPath,
+		Identity:        path.Base(binaryPath),
+		SigningMaterial: *signingMaterial,
 	}, nil
 }
 

--- a/quill/sign_kms_test.go
+++ b/quill/sign_kms_test.go
@@ -1,0 +1,189 @@
+package quill
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/quill/internal/test"
+	"github.com/anchore/quill/quill/pki/kms"
+)
+
+// TestSign_KMS exercises the full quill.Sign path through a KMS-backed signing
+// material, using the same fixture private keys + cert chains as the existing
+// TestSign. The expected CodeDirectory output is byte-identical because RSA
+// PKCS#1 v1.5 is deterministic and the CodeDirectory bytes are computed before
+// any signing — so any drift here means the KMS code path is producing a
+// different binary than the in-memory PEM path.
+func TestSign_KMS(t *testing.T) {
+	type args struct {
+		id                        string
+		binaryPath                string
+		keyFile                   string
+		certFile                  string
+		failWithoutFullChain      bool
+		skipAssertAgainstCodesign bool
+	}
+	tests := []struct {
+		name       string
+		args       args
+		assertions []test.OutputAssertion
+	}{
+		{
+			// mirrors "sign the syft binary - cert chain" in TestSign
+			name: "syft chain via kms",
+			args: args{
+				id:                   "syft-id",
+				binaryPath:           test.AssetCopy(t, "syft_unsigned"),
+				keyFile:              test.Asset(t, "chain-leaf-key.pem"),
+				certFile:             test.Asset(t, "chain.pem"),
+				failWithoutFullChain: true,
+			},
+			assertions: []test.OutputAssertion{
+				test.AssertContains("CodeDirectory v=20500 size=208904 flags=0x10000(runtime) hashes=6523+2 location=embedded"),
+				test.AssertContains("Hash type=sha256 size=32"),
+				test.AssertContains("CDHash=f08da6b0d99061c280b0c530648896f0f0cf5625"),
+				test.AssertContains("CMSDigest=f08da6b0d99061c280b0c530648896f0f0cf562527cbf1e2cebfc514452a24c3"),
+				test.AssertContains("Signature size="),
+				test.AssertContains("Authority=quill-test-leaf"),
+				test.AssertContains("Authority=quill-test-intermediate-ca"),
+				test.AssertContains("Authority=quill-test-root-ca"),
+				test.AssertContains("TeamIdentifier=not set"),
+			},
+		},
+		{
+			// mirrors "sign the syft binary - cert chain with OU (team ID)" — confirms
+			// the OU-derived team ID flows through the KMS path identically
+			name: "syft chain with OU via kms",
+			args: args{
+				id:                        "syft-id",
+				binaryPath:                test.AssetCopy(t, "syft_unsigned"),
+				keyFile:                   test.Asset(t, "chain-with-ou-leaf-key.pem"),
+				certFile:                  test.Asset(t, "chain-with-ou.pem"),
+				failWithoutFullChain:      true,
+				skipAssertAgainstCodesign: true, // fixture not configured to be trusted
+			},
+			assertions: []test.OutputAssertion{
+				test.AssertContains("CodeDirectory v=20500"),
+				test.AssertContains("flags=0x10000(runtime)"),
+				test.AssertContains("Hash type=sha256 size=32"),
+				test.AssertContains("Signature size="),
+				test.AssertContains("Authority=quill-test-leaf-with-ou"),
+				test.AssertContains("Authority=quill-test-intermediate-ca-with-ou"),
+				test.AssertContains("Authority=quill-test-root-ca-with-ou"),
+				test.AssertContains("TeamIdentifier=TESTTEAMID"),
+			},
+		},
+		{
+			// mirrors "sign multi arch binary - cert chain" — exercises the multi-arch
+			// path through KMS, which signs each slice independently
+			name: "ls universal via kms",
+			args: args{
+				id:                   "ls",
+				binaryPath:           test.AssetCopy(t, "ls_universal_signed"),
+				keyFile:              test.Asset(t, "chain-leaf-key.pem"),
+				certFile:             test.Asset(t, "chain.pem"),
+				failWithoutFullChain: true,
+			},
+			assertions: []test.OutputAssertion{
+				test.AssertContains("CodeDirectory v=20500 size=771 flags=0x10000(runtime) hashes=19+2 location=embedded"),
+				test.AssertContains("Hash type=sha256 size=32"),
+				test.AssertContains("CDHash=6d103445e8b004b078ec736b029868522e40d22d"),
+				test.AssertContains("CMSDigest=6d103445e8b004b078ec736b029868522e40d22daf33a010dde0c0cb61a2fdae"),
+				test.AssertContains("Signature size="),
+				test.AssertContains("Authority=quill-test-leaf"),
+				test.AssertContains("Authority=quill-test-intermediate-ca"),
+				test.AssertContains("Authority=quill-test-root-ca"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := "fakekms-" + sanitize(tt.name)
+			key := loadRSAKeyFromPEM(t, tt.args.keyFile)
+			kms.Register(&fakeKMSProvider{scheme: scheme, key: key})
+
+			cfg, err := NewSigningConfigFromKMS(
+				context.Background(),
+				tt.args.binaryPath,
+				scheme+":///test",
+				tt.args.certFile,
+				tt.args.failWithoutFullChain,
+			)
+			require.NoError(t, err)
+			cfg.WithIdentity(tt.args.id)
+
+			require.NoError(t, Sign(*cfg))
+
+			test.AssertDebugOutput(t, tt.args.binaryPath, tt.assertions...)
+			if !tt.args.skipAssertAgainstCodesign {
+				test.AssertAgainstCodesignTool(t, tt.args.binaryPath)
+			}
+		})
+	}
+}
+
+// loadRSAKeyFromPEM reads an unencrypted RSA private key from a PEM file.
+// Used to back a fake KMS with the same key material the P12-path tests use,
+// so we can compare outputs against TestSign's expected bytes.
+func loadRSAKeyFromPEM(t *testing.T, path string) *rsa.PrivateKey {
+	t.Helper()
+	by, err := os.ReadFile(path)
+	require.NoError(t, err)
+	block, _ := pem.Decode(by)
+	require.NotNil(t, block, "pem decode failed for %q", path)
+
+	var parsed any
+	if parsed, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		parsed, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+		require.NoError(t, err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	require.True(t, ok, "expected *rsa.PrivateKey, got %T", parsed)
+	return key
+}
+
+// sanitize converts a free-form test name into something usable as a URI scheme.
+func sanitize(s string) string {
+	r := strings.NewReplacer(" ", "-", "/", "-", "_", "-")
+	return strings.ToLower(r.Replace(s))
+}
+
+// --- fake KMS provider (in-process, holds a real RSA key) ---
+
+type fakeKMSProvider struct {
+	scheme string
+	key    *rsa.PrivateKey
+}
+
+func (p *fakeKMSProvider) Scheme() string { return p.scheme }
+
+func (p *fakeKMSProvider) Open(_ context.Context, uri string) (kms.Signer, error) {
+	return &fakeKMSSigner{
+		key:   p.key,
+		keyID: strings.TrimPrefix(uri, p.scheme+":///"),
+	}, nil
+}
+
+type fakeKMSSigner struct {
+	key   *rsa.PrivateKey
+	keyID string
+}
+
+func (s *fakeKMSSigner) Public() crypto.PublicKey { return &s.key.PublicKey }
+func (s *fakeKMSSigner) KeyID() string             { return s.keyID }
+func (s *fakeKMSSigner) Close() error              { return nil }
+
+func (s *fakeKMSSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return rsa.SignPKCS1v15(rand.Reader, s.key, opts.HashFunc(), digest)
+}


### PR DESCRIPTION
**This is not complete and needs a lot of work and verification.**

Adds an AWS KMS signing path so the Developer ID private key never has to live on the signing machine. The existing `--p12` flow is untouched.

What's in the branch:

- `--kms-key` and `--kms-cert-chain` flags on `quill sign` (and `sign-and-notarize`). URI scheme matches sigstore/cosign (`awskms:///alias/...` or `awskms:///arn:...`).
- New `quill csr` subcommand for enrolling a Developer ID cert against a KMS-resident keypair (Apple's normal CSR flow assumes the private key is local... with the key in KMS that path doesn't work).
- KMS-backed `crypto.Signer` implementation pinned to `RSASSA_PKCS1_V1_5_SHA_256`. We explicitly do not use `sigstore/sigstore/pkg/signature/kms` because it forces RSA-PSS, which Apple Developer ID CMS does not use.
- `TestSign_KMS` runs the existing trusted fixtures through an in-process fake KMS provider and asserts byte-identical CodeDirectory + CMS output to the P12 path. Passes `codesign --verify`.
- `.github/workflows/apple-e2e-kms.yaml` + `workflow_dispatch`-only pipeline that signs quill itself with a real KMS key + real Developer ID cert and submits to Apple Notary. The only thing that proves Apple actually accepts what we produce.
- `docs/hsm-signing.md`: threat model, end-to-end walkthrough, IAM policy, troubleshooting.

TODOs before the Apple E2E workflow can run (one-time, manual):

- [ ] Create an `RSA_2048` `SIGN_VERIFY` KMS key + alias (`alias/quill-ci-signing` or similar).
- [ ] Create an IAM role with `kms:Sign` + `kms:GetPublicKey` on that key, OIDC trust scoped to this repo + `main`.
- [ ] Run `quill csr` against the new key, submit to Apple Developer portal, assemble `chain.pem` from the issued cert + Apple intermediates.
- [ ] Set repo Variables (non-secret, cert chain is public material): `QUILL_KMS_KEY_URI`, `QUILL_KMS_CERT_CHAIN_PEM`, `AWS_KMS_SIGNING_ROLE_ARN`, `AWS_KMS_REGION`.
- [ ] (Existing) `APPLE_NOTARY_ISSUER`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_KEY` secrets reused as-is.
- [ ] Dispatch the workflow once to confirm the wiring end-to-end.

Out of scope, follow-up issues:

- GCP KMS (`gcpkms://`) and Azure Key Vault (`azurekms://`) providers.
- PKCS#11 provider (CloudHSM, YubiHSM, on-prem).
- ECDSA Developer ID support.

Closes #759